### PR TITLE
Fix homepage totalReactions

### DIFF
--- a/src/components/project-card/ProjectCardBadges.tsx
+++ b/src/components/project-card/ProjectCardBadges.tsx
@@ -99,6 +99,10 @@ const ProjectCardBadges = (props: IProjectCardBadges) => {
 		setReaction(props.reaction);
 	}, [props.reaction]);
 
+	useEffect(() => {
+		setTotalReactions(props.totalReactions);
+	}, [props.totalReactions]);
+
 	return (
 		<>
 			{showModal && (


### PR DESCRIPTION
Made totalReactions update on project card badge when props.totalReactions changes

It's a temporary solution for #175. It will not be needed if we solve #177 