### PR TITLE
Fixed Toast size on mobile devices

### DIFF
--- a/src/components/toasts/index.tsx
+++ b/src/components/toasts/index.tsx
@@ -1,3 +1,4 @@
+import { mediaQueries } from '@/lib/constants/constants';
 import {
 	brandColors,
 	Caption,
@@ -98,7 +99,7 @@ export const gToast = (message: string, options: IToast) => {
 };
 
 const ToastContainer = styled(Flex)<IToast>`
-	min-width: 580px;
+	min-width: 250px;
 	padding: 16px;
 	gap: 16px;
 	align-items: center;
@@ -157,6 +158,9 @@ const ToastContainer = styled(Flex)<IToast>`
 			}
 		}};
 	border-radius: 8px;
+	${mediaQueries.laptop} {
+		min-width: 580px;
+	}
 `;
 
 const IconContainer = styled.div``;


### PR DESCRIPTION
Now it looks like this on Mobile devices:

<img width="244" alt="image" src="https://user-images.githubusercontent.com/48887817/163709518-a49737b4-824b-4473-b06d-e3915474bb7a.png">
