### PR TITLE
Add donation failed messages

### DIFF
--- a/src/components/modals/DonateModal.tsx
+++ b/src/components/modals/DonateModal.tsx
@@ -22,9 +22,10 @@ import { IProjectAcceptedToken } from '@/apollo/types/gqlTypes';
 import { ISuccessDonation } from '@/components/views/donate/CryptoDonation';
 import { confirmDonation } from '@/components/views/donate/helpers';
 import { IModal } from '@/types/common';
+import { EDonationFailedType } from '@/components/modals/FailedDonation';
 
 export interface IDonateModalProps extends IModal {
-	setShowFailedModal: (i: boolean) => void;
+	setFailedModalType: (i: EDonationFailedType) => void;
 	setTxHash: (i: string) => void;
 	project: IProject;
 	token: IProjectAcceptedToken;

--- a/src/components/modals/FailedDonation.tsx
+++ b/src/components/modals/FailedDonation.tsx
@@ -1,32 +1,65 @@
 import { FC } from 'react';
 import { Lead, semanticColors } from '@giveth/ui-design-system';
 import styled from 'styled-components';
+import Image from 'next/image';
 import { Modal } from '@/components/modals/Modal';
 import { mediaQueries } from '@/lib/constants/constants';
 import { FlexCenter } from '@/components/styled-components/Flex';
 import { IModal } from '@/types/common';
 import ExternalLink from '@/components/ExternalLink';
+import DangerIcon from '/public/images/icons/danger_triangle.svg';
+
+export enum EDonationFailedType {
+	REJECTED = 'REJECTED',
+	FAILED = 'FAILED',
+	CANCELLED = 'CANCELLED',
+	NOT_SAVED = 'NOT_SAVED',
+}
 
 interface IProps extends IModal {
 	txUrl?: string;
+	type: EDonationFailedType;
 }
 
-const FailedDonation: FC<IProps> = ({ setShowModal, txUrl }) => {
+const FailedDonation: FC<IProps> = ({ setShowModal, txUrl, type }) => {
+	const messageContent = () => {
+		switch (type) {
+			case EDonationFailedType.REJECTED:
+				return <div>User denied the transaction!</div>;
+			case EDonationFailedType.CANCELLED:
+				return (
+					<div>
+						<p>Your transaction has been cancelled!</p>
+						Please go back and try again.
+					</div>
+				);
+			case EDonationFailedType.NOT_SAVED:
+				return (
+					<div>
+						<p>Your donation has NOT been saved!</p>
+						Please contact our support team.
+					</div>
+				);
+			default:
+				return (
+					<div>
+						<p>Your transaction has failed!</p>
+						Please go back and try again.
+					</div>
+				);
+		}
+	};
+
 	return (
 		<Modal
 			setShowModal={setShowModal}
 			headerTitle='Donation failed!'
 			headerTitlePosition='left'
 			headerColor={semanticColors.punch[500]}
-			headerIcon={
-				<img src={'/images/icons/danger_triangle.svg'} alt='danger' />
-			}
+			headerIcon={<Image src={DangerIcon} alt='danger' />}
 		>
 			<Container>
-				<Content>
-					<p>Your transaction has failed!</p>
-					Please go back and try again.
-				</Content>
+				<Content>{messageContent()}</Content>
 				{txUrl && (
 					<ExternalLink href={txUrl} title='View on Etherscan' />
 				)}
@@ -43,7 +76,7 @@ const Content = styled(Lead)`
 	border: 1px solid ${semanticColors.punch[700]};
 	margin-top: 42px;
 	margin-bottom: 48px;
-	> p {
+	p {
 		margin: 0 0 5px;
 	}
 

--- a/src/components/views/donate/CryptoDonation.tsx
+++ b/src/components/views/donate/CryptoDonation.tsx
@@ -52,7 +52,9 @@ import { ORGANIZATION } from '@/lib/constants/organizations';
 import { getERC20Info } from '@/lib/contracts';
 import GIVBackToast from '@/components/views/donate/GIVBackToast';
 import { DonateWrongNetwork } from '@/components/modals/DonateWrongNetwork';
-import FailedDonation from '@/components/modals/FailedDonation';
+import FailedDonation, {
+	EDonationFailedType,
+} from '@/components/modals/FailedDonation';
 import { useAppDispatch, useAppSelector } from '@/features/hooks';
 import {
 	setShowSignWithWallet,
@@ -117,7 +119,8 @@ const CryptoDonation = (props: {
 	const [acceptedTokens, setAcceptedTokens] =
 		useState<IProjectAcceptedToken[]>();
 	const [acceptedChains, setAcceptedChains] = useState<number[]>();
-	const [showFailedModal, setShowFailedModal] = useState(false);
+	const [failedModalType, setFailedModalType] =
+		useState<EDonationFailedType>();
 	const [txHash, setTxHash] = useState<string>();
 
 	const stopPolling = useRef<any>(null);
@@ -342,7 +345,7 @@ const CryptoDonation = (props: {
 				<DonateModal
 					setShowModal={setShowDonateModal}
 					setSuccessDonation={setSuccessDonation}
-					setShowFailedModal={setShowFailedModal}
+					setFailedModalType={setFailedModalType}
 					setTxHash={setTxHash}
 					project={project}
 					token={selectedToken}
@@ -354,10 +357,11 @@ const CryptoDonation = (props: {
 					}
 				/>
 			)}
-			{showFailedModal && (
+			{failedModalType && (
 				<FailedDonation
 					txUrl={formatTxLink(networkId, txHash)}
-					setShowModal={setShowFailedModal}
+					setShowModal={() => setFailedModalType(undefined)}
+					type={failedModalType}
 				/>
 			)}
 


### PR DESCRIPTION
Ref. #880 

I added different donation failed modal for different cases:

1. donations failed
2. donation is mined but not saved on our DB
3. User rejected the transaction!
4. donation cancelled
5. unknown error (is same as failed error)