### PR TITLE
add progress bar to file uploading

### DIFF
--- a/public/images/icons/image.svg
+++ b/public/images/icons/image.svg
@@ -1,5 +1,0 @@
-<svg width="49" height="49" viewBox="0 0 49 49" fill="none" xmlns="http://www.w3.org/2000/svg">
-<path d="M38.5 6.5H10.5C8.29086 6.5 6.5 8.29086 6.5 10.5V38.5C6.5 40.7091 8.29086 42.5 10.5 42.5H38.5C40.7091 42.5 42.5 40.7091 42.5 38.5V10.5C42.5 8.29086 40.7091 6.5 38.5 6.5Z" stroke="#BBC3D5" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
-<path d="M17.5 20.5C19.1569 20.5 20.5 19.1569 20.5 17.5C20.5 15.8431 19.1569 14.5 17.5 14.5C15.8431 14.5 14.5 15.8431 14.5 17.5C14.5 19.1569 15.8431 20.5 17.5 20.5Z" stroke="#BBC3D5" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
-<path d="M42.5 30.5L32.5 20.5L10.5 42.5" stroke="#BBC3D5" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
-</svg>

--- a/src/apollo/apolloClient.ts
+++ b/src/apollo/apolloClient.ts
@@ -19,6 +19,69 @@ const ssrMode = isSSRMode;
 
 export const APOLLO_STATE_PROP_NAME = '__APOLLO_STATE__';
 
+const parseHeaders = (rawHeaders: any) => {
+	const headers = new Headers();
+	// Replace instances of \r\n and \n followed by at least one space or horizontal tab with a space
+	// https://tools.ietf.org/html/rfc7230#section-3.2
+	const preProcessedHeaders = rawHeaders.replace(/\r?\n[\t ]+/g, ' ');
+	preProcessedHeaders.split(/\r?\n/).forEach((line: any) => {
+		const parts = line.split(':');
+		const key = parts.shift().trim();
+		if (key) {
+			const value = parts.join(':').trim();
+			headers.append(key, value);
+		}
+	});
+	return headers;
+};
+
+const uploadFetch = (url: string, options: any) =>
+	new Promise((resolve, reject) => {
+		const xhr = new XMLHttpRequest();
+		xhr.onload = () => {
+			const opts: any = {
+				status: xhr.status,
+				statusText: xhr.statusText,
+				headers: parseHeaders(xhr.getAllResponseHeaders() || ''),
+			};
+			opts.url =
+				'responseURL' in xhr
+					? xhr.responseURL
+					: opts.headers.get('X-Request-URL');
+			const body =
+				'response' in xhr ? xhr.response : (xhr as any).responseText;
+			resolve(new Response(body, opts));
+		};
+		xhr.onerror = () => {
+			reject(new TypeError('Network request failed'));
+		};
+		xhr.ontimeout = () => {
+			reject(new TypeError('Network request failed'));
+		};
+		xhr.open(options.method, url, true);
+
+		Object.keys(options.headers).forEach(key => {
+			xhr.setRequestHeader(key, options.headers[key]);
+		});
+
+		if (xhr.upload) {
+			xhr.upload.onprogress = options.onProgress;
+		}
+
+		options.onAbortPossible(() => {
+			xhr.abort();
+		});
+
+		xhr.send(options.body);
+	});
+
+const customFetch = (uri: any, options: any) => {
+	if (options.useUpload) {
+		return uploadFetch(uri, options);
+	}
+	return fetch(uri, options);
+};
+
 function createApolloClient() {
 	let userWalletAddress: string | null;
 	if (!ssrMode) {
@@ -27,6 +90,7 @@ function createApolloClient() {
 
 	const httpLink = createUploadLink({
 		uri: config.BACKEND_LINK,
+		fetch: customFetch as any,
 	}) as unknown as ApolloLink;
 
 	const authLink = setContext((_, { headers }) => {

--- a/src/components/FileUploader.tsx
+++ b/src/components/FileUploader.tsx
@@ -11,7 +11,7 @@ import {
 	neutralColors,
 	brandColors,
 } from '@giveth/ui-design-system';
-
+import { IconImage } from '@giveth/ui-design-system/lib/cjs/components/icons/Image';
 import { Flex } from './styled-components/Flex';
 import { showToastError } from '@/lib/helpers';
 import { client } from '@/apollo/apolloClient';
@@ -143,12 +143,8 @@ const FileUploader: FC<IFileUploader> = ({
 			) : (
 				<DropZone {...getRootProps()}>
 					<input {...getInputProps()} />
-					<Image
-						src='/images/icons/image.svg'
-						width={36}
-						height={36}
-						alt='image'
-					/>
+					<IconImage size={32} color={neutralColors.gray[500]} />
+					<br />
 					<P>
 						{`Drag & drop your files here or `}
 						<span onClick={open}>Upload from device.</span>

--- a/src/components/ImageUploader.tsx
+++ b/src/components/ImageUploader.tsx
@@ -54,7 +54,10 @@ const ImageUploader: FC<IImageUploader> = props => {
 						justifyContent='space-between'
 					>
 						<Flex justifyContent='space-between'>
-							<Subline>{file.name + ` (${progress}%)`}</Subline>
+							<Subline>
+								<span>{file.name + ' '}</span>
+								{!url && <span>({progress}%)</span>}
+							</Subline>
 							{isUploading && (
 								<DeleteRow onClick={onDelete}>
 									<IconX size={16} />

--- a/src/components/ProgressBar.tsx
+++ b/src/components/ProgressBar.tsx
@@ -1,0 +1,26 @@
+import styled from 'styled-components';
+import { brandColors, neutralColors } from '@giveth/ui-design-system';
+
+const ProgressBar = (props: { percentage: number }) => {
+	return (
+		<Container>
+			<Bar width={props.percentage / 100} />
+		</Container>
+	);
+};
+
+const Container = styled.div`
+	background: ${neutralColors.gray[300]};
+	height: 3px;
+	border-radius: 5px;
+`;
+
+const Bar = styled.div<{ width: number }>`
+	background: ${brandColors.giv[500]};
+	border-radius: 5px;
+	width: ${props => props.width * 100}%;
+	height: 100%;
+	transition: width 0.3s ease-in-out;
+`;
+
+export default ProgressBar;

--- a/src/components/modals/EditUserModal.tsx
+++ b/src/components/modals/EditUserModal.tsx
@@ -20,6 +20,7 @@ import { fetchUserByAddress } from '@/features/user/user.thunks';
 import Input, { InputSize } from '../Input';
 import { requiredOptions, validators } from '@/lib/constants/regex';
 import { useModalAnimation } from '@/hooks/useModalAnimation';
+import useUpload from '@/hooks/useUpload';
 
 enum EditStatusType {
 	INFO,
@@ -43,9 +44,9 @@ const EditUserModal = ({ setShowModal, user }: IEditUserModal) => {
 	const [editStatus, setEditStatus] = useState<EditStatusType>(
 		EditStatusType.INFO,
 	);
-	const [avatar, setAvatar] = useState<string>('');
-	const [file, setFile] = useState<File>();
-	const [uploading, setUploading] = useState(false);
+
+	const useUploadProps = useUpload();
+	const { url, onDelete } = useUploadProps;
 
 	const {
 		register,
@@ -61,7 +62,7 @@ const EditUserModal = ({ setShowModal, user }: IEditUserModal) => {
 		try {
 			const { data: response } = await updateUser({
 				variables: {
-					avatar,
+					avatar: url,
 				},
 			});
 			if (response.updateUser) {
@@ -71,6 +72,7 @@ const EditUserModal = ({ setShowModal, user }: IEditUserModal) => {
 					type: ToastType.SUCCESS,
 					title: 'Success',
 				});
+				onDelete();
 			} else {
 				throw 'updateUser false';
 			}
@@ -131,25 +133,18 @@ const EditUserModal = ({ setShowModal, user }: IEditUserModal) => {
 			<Wrapper>
 				{editStatus === EditStatusType.PHOTO ? (
 					<Flex flexDirection='column' gap='36px'>
-						<ImageUploader
-							url={avatar}
-							setUrl={setAvatar}
-							file={file}
-							setFile={setFile}
-							uploading={uploading}
-							setUploading={setUploading}
-						/>
+						<ImageUploader {...useUploadProps} />
 						<Button
 							buttonType='secondary'
 							label='SAVE'
 							onClick={onSaveAvatar}
-							disabled={!avatar}
+							disabled={!url}
 						/>
 						<TextButton
 							buttonType='texty'
 							label='cancel'
 							onClick={() => {
-								setAvatar('');
+								onDelete();
 								setEditStatus(EditStatusType.INFO);
 							}}
 						/>

--- a/src/components/views/create/imageInput/ImageInput.tsx
+++ b/src/components/views/create/imageInput/ImageInput.tsx
@@ -1,4 +1,4 @@
-import React, { Dispatch, SetStateAction, useState } from 'react';
+import React, { Dispatch, FC, SetStateAction, useState } from 'react';
 import {
 	H5,
 	Caption,
@@ -16,6 +16,7 @@ import { OurImages } from '@/lib/constants/constants';
 import { FlexCenter } from '@/components/styled-components/Flex';
 import ImageUploader from '@/components/ImageUploader';
 import ExternalLink from '@/components/ExternalLink';
+import useUpload from '@/hooks/useUpload';
 
 const ImageSearch = dynamic(() => import('./ImageSearch'), {
 	ssr: false,
@@ -34,36 +35,25 @@ interface ImageInputProps {
 	setIsLoading: Dispatch<SetStateAction<boolean>>;
 }
 
-const ImageInput = (props: ImageInputProps) => {
-	const { value, setValue, setIsLoading } = props;
-
+const ImageInput: FC<ImageInputProps> = ({ value, setValue, setIsLoading }) => {
 	const [isUploadTab, setIsUploadTab] = useState(true);
 	const [attributes, setAttributes] = useState({ name: '', username: '' });
-	const [uploading, setUploading] = useState(false);
-	const [file, setFile] = useState<File>();
+
+	const useUploadProps = useUpload(setValue, setIsLoading);
+	const { onDelete } = useUploadProps;
+	const imageUploaderProps = { ...useUploadProps, url: value };
 
 	const removeAttributes = () => setAttributes({ name: '', username: '' });
 
 	const removeImage = () => {
-		setValue('');
-		setFile(undefined);
-		removeAttributes();
-	};
-
-	const handleUpload = (image: string) => {
-		setValue(image);
+		onDelete();
 		removeAttributes();
 	};
 
 	const pickBg = (index: number) => {
+		onDelete();
 		setValue(`/images/defaultProjectImages/${index}.png`);
-		setFile(undefined);
 		removeAttributes();
-	};
-
-	const handleUploading = (i: boolean) => {
-		setUploading(i);
-		setIsLoading(i);
 	};
 
 	return (
@@ -97,14 +87,7 @@ const ImageInput = (props: ImageInputProps) => {
 					/>
 				)}
 				{(isUploadTab || (!isUploadTab && value)) && (
-					<ImageUploader
-						url={value}
-						setUrl={handleUpload}
-						uploading={uploading}
-						setUploading={handleUploading}
-						file={file}
-						setFile={setFile}
-					/>
+					<ImageUploader {...imageUploaderProps} />
 				)}
 
 				{attributes.name && (

--- a/src/components/views/onboarding/PhotoStep.tsx
+++ b/src/components/views/onboarding/PhotoStep.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useEffect, useState } from 'react';
+import React, { FC, useEffect } from 'react';
 import styled from 'styled-components';
 import Image from 'next/image';
 import { Lead } from '@giveth/ui-design-system';
@@ -21,16 +21,16 @@ import { setShowSignWithWallet } from '@/features/modal/modal.slice';
 import { useAppDispatch, useAppSelector } from '@/features/hooks';
 import { fetchUserByAddress } from '@/features/user/user.thunks';
 import { Col } from '@/components/Grid';
+import useUpload from '@/hooks/useUpload';
 
 const PhotoStep: FC<IStep> = ({ setStep }) => {
-	const [url, setUrl] = useState<string>('');
-	const [file, setFile] = useState<File>();
-	const [uploading, setUploading] = useState(false);
-
 	const [updateUser] = useMutation(UPDATE_USER);
 	const dispatch = useAppDispatch();
 	const isSignedIn = useAppSelector(state => state.user.isSignedIn);
 	const { account } = useWeb3React();
+
+	const useUploadProps = useUpload();
+	const { url, onDelete } = useUploadProps;
 
 	useEffect(() => {
 		if (!isSignedIn) {
@@ -52,6 +52,7 @@ const PhotoStep: FC<IStep> = ({ setStep }) => {
 					type: ToastType.SUCCESS,
 					title: 'Success',
 				});
+				onDelete();
 				return true;
 			} else {
 				throw 'updateUser false';
@@ -72,49 +73,40 @@ const PhotoStep: FC<IStep> = ({ setStep }) => {
 	};
 
 	return (
-		<>
-			<OnboardStep>
-				<ProfilePicWrapper>
-					<Image
-						src='/images/avatar.svg'
-						width={128}
-						height={128}
-						alt='user avatar'
-					/>
-				</ProfilePicWrapper>
-				<Desc>
-					This is how you look right now! Strange, right?
-					<br />
-					Upload a photo that represents who you are.
-				</Desc>
-				<ImageUploader
-					url={url}
-					setUrl={setUrl}
-					file={file}
-					setFile={setFile}
-					uploading={uploading}
-					setUploading={setUploading}
+		<OnboardStep>
+			<ProfilePicWrapper>
+				<Image
+					src='/images/avatar.svg'
+					width={128}
+					height={128}
+					alt='user avatar'
 				/>
-				<OnboardActionsContianer>
-					<Col xs={12} md={7}>
-						<SaveButton
-							label='SAVE'
-							onClick={onSave}
-							disabled={!url}
-							size='medium'
-						/>
-					</Col>
-					<Col xs={12} md={2}>
-						<SkipButton
-							label='Do it later'
-							size='medium'
-							buttonType='texty'
-							onClick={() => setStep(OnboardSteps.DONE)}
-						/>
-					</Col>
-				</OnboardActionsContianer>
-			</OnboardStep>
-		</>
+			</ProfilePicWrapper>
+			<Desc>
+				This is how you look right now! Strange, right?
+				<br />
+				Upload a photo that represents who you are.
+			</Desc>
+			<ImageUploader {...useUploadProps} />
+			<OnboardActionsContianer>
+				<Col xs={12} md={7}>
+					<SaveButton
+						label='SAVE'
+						onClick={onSave}
+						disabled={!url}
+						size='medium'
+					/>
+				</Col>
+				<Col xs={12} md={2}>
+					<SkipButton
+						label='Do it later'
+						size='medium'
+						buttonType='texty'
+						onClick={() => setStep(OnboardSteps.DONE)}
+					/>
+				</Col>
+			</OnboardActionsContianer>
+		</OnboardStep>
 	);
 };
 

--- a/src/components/views/verification/Common.tsx
+++ b/src/components/views/verification/Common.tsx
@@ -1,9 +1,4 @@
-import {
-	brandColors,
-	IconTrash,
-	neutralColors,
-} from '@giveth/ui-design-system';
-import styled from 'styled-components';
+import { IconTrash, neutralColors } from '@giveth/ui-design-system';
 import { FC } from 'react';
 import menuList from '@/components/views/verification/menu/menuList';
 import { useVerificationData } from '@/context/verification.context';
@@ -11,6 +6,7 @@ import {
 	ButtonStyled,
 	RemoveBtn,
 } from '@/components/views/verification/Common.sc';
+import ProgressBar from '@/components/ProgressBar';
 
 interface IRemoveBtnProps {
 	onClick?: () => void;
@@ -37,27 +33,9 @@ export const RemoveIcon: FC<IRemoveBtnProps> = ({ onClick }) => {
 	);
 };
 
-export const ProgressBar = () => {
+export const StepsProgressBar = () => {
 	const stepsCount = menuList.length;
 	const { step } = useVerificationData();
 	const _step = step < 0 ? 0 : step; // For width animation on initial load
-	return (
-		<Container>
-			<Bar width={(_step + 1) / stepsCount} />
-		</Container>
-	);
+	return <ProgressBar percentage={((_step + 1) * 100) / stepsCount} />;
 };
-
-const Container = styled.div`
-	background: ${neutralColors.gray[300]};
-	height: 3px;
-	border-radius: 5px;
-`;
-
-const Bar = styled.div<{ width: number }>`
-	background: ${brandColors.giv[500]};
-	border-radius: 5px;
-	width: ${props => props.width * 100}%;
-	height: 100%;
-	transition: width 0.8s ease-in-out;
-`;

--- a/src/components/views/verification/menu/DesktopMenu.tsx
+++ b/src/components/views/verification/menu/DesktopMenu.tsx
@@ -5,7 +5,7 @@ import { Col } from '@/components/Grid';
 import { Shadow } from '@/components/styled-components/Shadow';
 import menuList from '@/components/views/verification/menu/menuList';
 import { useVerificationData } from '@/context/verification.context';
-import { ProgressBar } from '@/components/views/verification/Common';
+import { StepsProgressBar } from '@/components/views/verification/Common';
 import { findStepByName } from '@/lib/verification';
 
 const DesktopMenu = () => {
@@ -17,7 +17,7 @@ const DesktopMenu = () => {
 		<MenuSection sm={3.75} md={2.75}>
 			<MenuTitle>Verified status for</MenuTitle>
 			<MenuTitle isActive>{title}</MenuTitle>
-			<ProgressBar />
+			<StepsProgressBar />
 			{menuList.map((item, index) => {
 				const isClickable =
 					!!lastStepIndex && index <= lastStepIndex + 1;

--- a/src/components/views/verification/menu/MobileMenu.tsx
+++ b/src/components/views/verification/menu/MobileMenu.tsx
@@ -4,7 +4,7 @@ import Image from 'next/image';
 import { useState } from 'react';
 import { useVerificationData } from '@/context/verification.context';
 import { Shadow } from '@/components/styled-components/Shadow';
-import { ProgressBar } from '@/components/views/verification/Common';
+import { StepsProgressBar } from '@/components/views/verification/Common';
 import menuList from '@/components/views/verification/menu/menuList';
 import MenuModal from '@/components/views/verification/menu/MenuModal';
 import MenuIcon from '/public/images/menu/drawer_menu_black.svg';
@@ -26,7 +26,7 @@ const MobileMenu = () => {
 				<StatusSection>
 					<B>Verified status for</B>
 					<B>{title}</B>
-					<ProgressBar />
+					<StepsProgressBar />
 				</StatusSection>
 			</Wrapper>
 			{showMenu && <MenuModal setShowModal={setShowMenu} />}

--- a/src/hooks/useUpload.tsx
+++ b/src/hooks/useUpload.tsx
@@ -45,6 +45,7 @@ const useUpload = (
 		multiple: false,
 		noClick: true,
 		noKeyboard: true,
+		useFsAccessApi: false,
 		onDrop: async (acceptedFiles: File[]) => {
 			setFile(acceptedFiles[0]);
 			setIsUploading(true);

--- a/src/hooks/useUpload.tsx
+++ b/src/hooks/useUpload.tsx
@@ -1,0 +1,79 @@
+import { useRef, useState } from 'react';
+import { useDropzone } from 'react-dropzone';
+import { client } from '@/apollo/apolloClient';
+import { UPLOAD_PROFILE_PHOTO } from '@/apollo/gql/gqlUser';
+
+const useUpload = (
+	setUrlCallback?: (url: string) => void,
+	setIsUploadingCallback?: (isUploading: boolean) => void,
+) => {
+	const abort = useRef(() => {});
+
+	const [progress, setProgress] = useState<number>(0);
+	const [file, setFile] = useState<File>();
+	const [isUploading, setIsUploading] = useState(false);
+	const [url, setUrl] = useState<string>('');
+
+	const onDrop = async (acceptedFiles: File[]) => {
+		const { data: imageUploaded } = await client.mutate({
+			mutation: UPLOAD_PROFILE_PHOTO,
+			variables: {
+				fileUpload: {
+					image: acceptedFiles[0],
+				},
+			},
+			context: {
+				fetchOptions: {
+					useUpload: true,
+					onProgress: (ev: ProgressEvent) => {
+						setProgress(Math.round((ev.loaded * 100) / ev.total));
+					},
+					onAbortPossible: (abortHandler: any) => {
+						abort.current = abortHandler;
+					},
+				},
+			},
+		});
+		setUrl(imageUploaded.upload);
+		setUrlCallback && setUrlCallback(imageUploaded.upload);
+	};
+
+	const dropzoneProps = useDropzone({
+		accept: {
+			'image/*': ['.jpg', '.jpeg', '.png', '.gif'],
+		},
+		multiple: false,
+		noClick: true,
+		noKeyboard: true,
+		onDrop: async (acceptedFiles: File[]) => {
+			setFile(acceptedFiles[0]);
+			setIsUploading(true);
+			setIsUploadingCallback && setIsUploadingCallback(true);
+			await onDrop(acceptedFiles);
+			setProgress(0);
+			setIsUploading(false);
+			setIsUploadingCallback && setIsUploadingCallback(false);
+		},
+	});
+
+	const onDelete = () => {
+		abort.current();
+		url && setUrl('');
+		setUrlCallback && setUrlCallback('');
+		file && setFile(undefined);
+		progress !== 0 && setProgress(0);
+		isUploading && setIsUploading(false);
+		setIsUploadingCallback && setIsUploadingCallback(false);
+	};
+
+	return {
+		progress,
+		isUploading,
+		file,
+		url,
+		dropzoneProps,
+		onDelete,
+	};
+};
+
+export default useUpload;


### PR DESCRIPTION
Ref. #1361 

1. Add progress bar and upload cancel button to file uploading components (create project page, edit user modal and onboarding page)
2. On create project page, when user selects a default background picture (four color slots) or the remove button, all picture uploading processes should be aborted.