### PR TITLE
add animation to multi-addresses

### DIFF
--- a/src/components/toasts/InlineToast.tsx
+++ b/src/components/toasts/InlineToast.tsx
@@ -16,9 +16,10 @@ export enum EToastType {
 interface IProps {
 	message: string;
 	type: EToastType;
+	isHidden?: boolean;
 }
 
-const InlineToast: FC<IProps> = ({ message, type }) => {
+const InlineToast: FC<IProps> = ({ message, type, isHidden }) => {
 	const colorType: keyof typeof semanticColors =
 		type === EToastType.Error
 			? 'punch'
@@ -27,7 +28,10 @@ const InlineToast: FC<IProps> = ({ message, type }) => {
 			: 'jade';
 
 	return (
-		<Container colorType={colorType}>
+		<Container
+			className={isHidden ? 'fadeOut' : 'fadeIn'}
+			colorType={colorType}
+		>
 			{type === EToastType.Success ? (
 				<IconCheckmarkCircle />
 			) : (

--- a/src/components/views/create/WalletAddressInput.tsx
+++ b/src/components/views/create/WalletAddressInput.tsx
@@ -23,6 +23,7 @@ import { Flex, FlexCenter } from '@/components/styled-components/Flex';
 import CheckBox from '@/components/Checkbox';
 import { getAddressFromENS, isAddressENS } from '@/lib/wallet';
 import InlineToast, { EToastType } from '@/components/toasts/InlineToast';
+import useDelay from '@/hooks/useDelay';
 
 interface IProps {
 	networkId: number;
@@ -65,6 +66,9 @@ const WalletAddressInput: FC<IProps> = ({
 	const isAddressUsed =
 		errorMessage.indexOf('is already being used for a project') > -1;
 
+	const delayedResolvedENS = useDelay(!!resolvedENS);
+	const delayedIsAddressUsed = useDelay(isAddressUsed);
+
 	let disabled: boolean;
 	if (isGnosis) disabled = !isActive;
 	else disabled = !isActive && !sameAddress;
@@ -93,6 +97,7 @@ const WalletAddressInput: FC<IProps> = ({
 		try {
 			clearErrors(inputName);
 			if (disabled) return true;
+			if (address.length === 0) return 'This field is required';
 			setResolvedENS('');
 			let _address = (' ' + address).slice(1);
 			setIsValidating(true);
@@ -178,14 +183,16 @@ const WalletAddressInput: FC<IProps> = ({
 				registerOptions={{ validate: addressValidation }}
 				error={isAddressUsed ? undefined : error}
 			/>
-			{resolvedENS && (
+			{delayedResolvedENS && (
 				<InlineToast
+					isHidden={!resolvedENS}
 					type={EToastType.Success}
 					message={'Resolves as ' + resolvedENS}
 				/>
 			)}
-			{isAddressUsed && (
+			{delayedIsAddressUsed && (
 				<InlineToast
+					isHidden={!isAddressUsed}
 					type={EToastType.Error}
 					message='This address is already used for another project. Please enter an address which is not currently associated with any other project.'
 				/>

--- a/src/hooks/useDelay.tsx
+++ b/src/hooks/useDelay.tsx
@@ -1,0 +1,15 @@
+import { useEffect, useState } from 'react';
+
+const useDelay = (show: boolean, delay?: number) => {
+	const [delayedShow, setDelayedShow] = useState(show);
+
+	useEffect(() => {
+		setTimeout(() => {
+			setDelayedShow(show);
+		}, delay || 300);
+	}, [show]);
+
+	return delayedShow;
+};
+
+export default useDelay;


### PR DESCRIPTION
Ref. #1185 

1. Fade-in and fade-out animation is added to the resolved address toast massage and to the wallet address already used error message
2. This field is required error message is added when wallet address input is empty