### PR TITLE
Discontinued GIVfarm cards

### DIFF
--- a/src/components/cards/BaseStakingCard.sc.tsx
+++ b/src/components/cards/BaseStakingCard.sc.tsx
@@ -181,7 +181,7 @@ export const DisableModalContent = styled.div`
 	border-radius: 12px;
 	box-shadow: ${Shadow.Neutral[400]};
 	max-width: 80%;
-	height: 156px;
+	height: 170px;
 	padding: 16px 12px;
 `;
 

--- a/src/components/cards/BaseStakingCard.tsx
+++ b/src/components/cards/BaseStakingCard.tsx
@@ -153,14 +153,11 @@ const BaseStakingCard: FC<IBaseStakingCardProps> = ({
 		BUY_LINK,
 		unit,
 		farmStartTimeMS,
-		active: activePool,
+		active,
 		archived,
 		discontinued,
 		introCard,
 	} = poolStakingConfig;
-
-	const active =
-		activePool && (!discontinued || getNowUnixMS() > discontinued); // pool is no longer active if discontinuation date is over
 
 	const {
 		apr,
@@ -251,20 +248,25 @@ const BaseStakingCard: FC<IBaseStakingCardProps> = ({
 									alt='question'
 								/>
 							</DisableModalImage>
-							<div>
+							<Flex
+								flexDirection='column'
+								justifyContent='space-evenly'
+							>
 								<DisableModalText weight={700}>
-									This pool is no longer available
+									{discontinued
+										? 'Attention Farmers!'
+										: 'This pool is no longer available'}
 								</DisableModalText>
-								<br />
 								<DisableModalText>
-									Please unstake your tokens and check out
-									other available pools.
+									{discontinued
+										? 'This farm is ending soon, move your funds to another farm to keep earning rewards.'
+										: 'Please unstake your tokens and check out other available pools.'}
 								</DisableModalText>
 								<DisableModalCloseButton
 									label='GOT IT'
 									onClick={() => setDisableModal(false)}
 								/>
-							</div>
+							</Flex>
 						</DisableModalContent>
 					</DisableModal>
 				)}

--- a/src/components/cards/BaseStakingCard.tsx
+++ b/src/components/cards/BaseStakingCard.tsx
@@ -153,10 +153,14 @@ const BaseStakingCard: FC<IBaseStakingCardProps> = ({
 		BUY_LINK,
 		unit,
 		farmStartTimeMS,
-		active,
+		active: activePool,
 		archived,
+		discontinued,
 		introCard,
 	} = poolStakingConfig;
+
+	const active =
+		activePool && (!discontinued || getNowUnixMS() > discontinued); // pool is no longer active if discontinuation date is over
 
 	const {
 		apr,
@@ -236,7 +240,7 @@ const BaseStakingCard: FC<IBaseStakingCardProps> = ({
 	return (
 		<>
 			<StakingPoolContainer>
-				{(!active || archived) && disableModal && (
+				{(!active || archived || discontinued) && disableModal && (
 					<DisableModal>
 						<DisableModalContent>
 							<DisableModalImage>

--- a/src/components/homeTabs/GIVfarm.tsx
+++ b/src/components/homeTabs/GIVfarm.tsx
@@ -54,13 +54,7 @@ const renderPools = (
 ) => {
 	const rightNow = getNowUnixMS();
 	return pools
-		.filter(p =>
-			showArchivedPools
-				? true
-				: p.active &&
-				  (!p?.discontinued || rightNow < p?.discontinued) && // shows card if time of discontinuation isn't over
-				  !p.archived,
-		)
+		.filter(p => (showArchivedPools ? true : p.active && !p.archived))
 		.map((poolStakingConfig, idx) => ({ poolStakingConfig, idx }))
 		.sort(
 			(
@@ -154,16 +148,7 @@ export const TabGIVfarmBottom = () => {
 	const [showArchivedPools, setArchivedPools] = useState(false);
 
 	const mainnetGIVStaking = getGivStakingConfig(config.MAINNET_CONFIG);
-	const mainGIVStakeDiscontinued =
-		mainnetGIVStaking.discontinued &&
-		getNowUnixMS() > mainnetGIVStaking.discontinued;
-
 	const xdaiGIVStaking = getGivStakingConfig(config.XDAI_CONFIG);
-
-	const xdaiGIVStakeDiscontinued =
-		xdaiGIVStaking.discontinued &&
-		getNowUnixMS() > xdaiGIVStaking.discontinued;
-
 	return (
 		<GIVfarmBottomContainer>
 			<Container>
@@ -231,8 +216,8 @@ export const TabGIVfarmBottom = () => {
 				{chainId === config.XDAI_NETWORK_NUMBER && (
 					<>
 						<PoolRow>
-							{(showArchivedPools ||
-								!xdaiGIVStakeDiscontinued) && (
+							{(!xdaiGIVStaking.archived ||
+								showArchivedPools) && (
 								<Col sm={6} lg={4}>
 									<StakingPoolCard
 										network={config.XDAI_NETWORK_NUMBER}
@@ -262,8 +247,8 @@ export const TabGIVfarmBottom = () => {
 								!givEconomySupportedNetworks.includes(chainId)
 							}
 						>
-							{(showArchivedPools ||
-								!mainGIVStakeDiscontinued) && (
+							{(!mainnetGIVStaking.archived ||
+								showArchivedPools) && (
 								<Col sm={6} lg={4}>
 									<StakingPoolCard
 										network={config.MAINNET_NETWORK_NUMBER}

--- a/src/components/homeTabs/GIVfarm.tsx
+++ b/src/components/homeTabs/GIVfarm.tsx
@@ -39,7 +39,6 @@ import { givEconomySupportedNetworks } from '@/lib/constants/constants';
 import { shortenAddress } from '@/lib/helpers';
 import { Col, Container, Row } from '@/components/Grid';
 import links from '@/lib/constants/links';
-import { getNowUnixMS } from '@/helpers/time';
 import {
 	DaoCard,
 	DaoCardTitle,
@@ -52,7 +51,6 @@ const renderPools = (
 	network: number,
 	showArchivedPools?: boolean,
 ) => {
-	const rightNow = getNowUnixMS();
 	return pools
 		.filter(p => (showArchivedPools ? true : p.active && !p.archived))
 		.map((poolStakingConfig, idx) => ({ poolStakingConfig, idx }))

--- a/src/config/development.ts
+++ b/src/config/development.ts
@@ -9,6 +9,7 @@ import { gwei2wei } from '@/helpers/blockchain';
 
 const INFURA_API_KEY = process.env.NEXT_PUBLIC_INFURA_API_KEY;
 const BASE_ROUTE = 'https://serve.giveth.io';
+const SEPT_8TH_2022 = 1662595200000;
 // IMPORTANT: Using dev to make it work until staging is merged
 // const BASE_ROUTE = 'https://dev.serve.giveth.io';
 
@@ -65,6 +66,7 @@ const config: EnvConfig = {
 					'https://app.uniswap.org/#/add/v2/0x4F96Fe3b7A6Cf9725f59d353F723c1bDb64CA6Aa/0x29434A25abd94AE882aA883eea81585Aaa5b078D?chain=kovan',
 				unit: 'LP',
 				active: true,
+				discontinued: SEPT_8TH_2022,
 			},
 			{
 				POOL_ADDRESS: '0x8a6b25e33b12d1bb6929a8793961076bd1f9d3eb',

--- a/src/config/production.ts
+++ b/src/config/production.ts
@@ -47,7 +47,6 @@ const config: EnvConfig = {
 			LM_ADDRESS: '0x4B9EfAE862a1755F7CEcb021856D467E86976755',
 			BUY_LINK:
 				'https://app.uniswap.org/#/swap?outputCurrency=0x900db999074d9277c5da2a43f252d74366230da0',
-			active: true,
 			discontinued: SEPT_8TH_2022,
 		},
 

--- a/src/config/production.ts
+++ b/src/config/production.ts
@@ -9,6 +9,7 @@ import { gwei2wei } from '@/helpers/blockchain';
 
 const INFURA_API_KEY = process.env.NEXT_PUBLIC_INFURA_API_KEY;
 const BASE_ROUTE = 'https://mainnet.serve.giveth.io';
+const SEPT_8TH_2022 = 1662595200000;
 
 const config: EnvConfig = {
 	BACKEND_LINK: 'https://mainnet.serve.giveth.io/graphql',
@@ -46,6 +47,8 @@ const config: EnvConfig = {
 			LM_ADDRESS: '0x4B9EfAE862a1755F7CEcb021856D467E86976755',
 			BUY_LINK:
 				'https://app.uniswap.org/#/swap?outputCurrency=0x900db999074d9277c5da2a43f252d74366230da0',
+			active: true,
+			discontinued: SEPT_8TH_2022,
 		},
 
 		nodeUrl: 'https://mainnet.infura.io/v3/' + INFURA_API_KEY,
@@ -63,6 +66,7 @@ const config: EnvConfig = {
 				unit: 'LP',
 				farmStartTimeMS: 1651345200000,
 				active: true,
+				discontinued: SEPT_8TH_2022,
 			},
 			{
 				POOL_ADDRESS: '0xc3151A58d519B94E915f66B044De3E55F77c2dd9',
@@ -220,6 +224,7 @@ const config: EnvConfig = {
 					'https://gnosis.sushi.com/add/0x6A023CCd1ff6F2045C3309768eAd9E68F978f6e1/0x4f4F9b8D5B4d0Dc10506e5551B0513B61fD59e75',
 				unit: 'LP',
 				active: true,
+				discontinued: SEPT_8TH_2022,
 			},
 			{
 				POOL_ADDRESS: '0xB7189A7Ea38FA31210A79fe282AEC5736Ad5fA57',
@@ -232,6 +237,7 @@ const config: EnvConfig = {
 					'https://app.honeyswap.org/#/add/0x4f4F9b8D5B4d0Dc10506e5551B0513B61fD59e75/xdai',
 				unit: 'LP',
 				active: true,
+				discontinued: SEPT_8TH_2022, // change this to  archived: true when it's over
 				farmStartTimeMS: 1656086400000,
 			},
 		],

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -4,6 +4,8 @@ export interface BasicStakingConfig {
 	BUY_LINK?: string;
 	farmStartTimeMS?: number;
 	icon?: string;
+	active?: boolean;
+	discontinued?: number;
 }
 export enum StakingPlatform {
 	GIVETH = 'Staking',
@@ -55,6 +57,7 @@ export interface SimplePoolStakingConfig extends BasicStakingConfig {
 	unit: string;
 	active: boolean;
 	archived?: boolean;
+	discontinued?: number;
 	introCard?: IntroCardConfig;
 }
 

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -4,8 +4,6 @@ export interface BasicStakingConfig {
 	BUY_LINK?: string;
 	farmStartTimeMS?: number;
 	icon?: string;
-	active?: boolean;
-	discontinued?: number;
 }
 export enum StakingPlatform {
 	GIVETH = 'Staking',
@@ -116,7 +114,7 @@ export interface BasicNetworkConfig {
 	gGIV_ADDRESS?: string;
 	tokenAddressOnUniswapV2: string; // For price purpose in test env, on production this must have the same value of `TOKEN_ADDRESS`
 	TOKEN_DISTRO_ADDRESS: string;
-	GIV: BasicStakingConfig;
+	GIV: BasicStakingConfig | SimplePoolStakingConfig;
 	nodeUrl: string;
 	chainId: string; // A 0x-prefixed hexadecimal string
 	chainName: string;


### PR DESCRIPTION
Sets discontinuation for production farms to stop showing on September 8th as it is exactly 3 weeks after August 18th.

Before that date we'll display them by default and tell the user to remove all liquidity from there

@laurenluz  @divine-comedian we can change the date if you disagree

Test with production env