### PR TITLE
Change "Gnosis chain" name to match https://chainlist.wtf/

### DIFF
--- a/src/config/production.ts
+++ b/src/config/production.ts
@@ -205,7 +205,7 @@ const config: EnvConfig = {
 
 	XDAI_CONFIG: {
 		chainId: '0x64',
-		chainName: 'Gnosis Chain',
+		chainName: 'Gnosis',
 		nativeCurrency: {
 			name: 'XDAI',
 			symbol: 'XDAI',


### PR DESCRIPTION
This should fix Metamask warning about name not matching chain ID.

![image](https://user-images.githubusercontent.com/8781107/204067619-0bc5c98c-f82d-431b-ad36-e9c072da939a.png)
