### PR TITLE
Hostname added instead of pathname on token signature for SIWE

### DIFF
--- a/src/components/modals/SignWithWalletModal.tsx
+++ b/src/components/modals/SignWithWalletModal.tsx
@@ -61,12 +61,17 @@ export const SignWithWalletModal: FC<IProps> = ({ setShowModal, callback }) => {
 							return dispatch(setShowWelcomeModal(true));
 						}
 						setLoading(true);
+						let host;
+						if (typeof window !== 'undefined') {
+							host = window.location.origin;
+						}
 						const signature = await dispatch(
 							signToGetToken({
 								address: account,
 								chainId,
 								signer: library?.getSigner(),
 								pathname: router.pathname,
+								host,
 							}),
 						);
 						setLoading(false);

--- a/src/features/user/user.thunks.ts
+++ b/src/features/user/user.thunks.ts
@@ -18,14 +18,14 @@ export const fetchUserByAddress = createAsyncThunk(
 export const signToGetToken = createAsyncThunk(
 	'user/signToGetToken',
 	async (
-		{ address, chainId, signer, pathname }: ISignToGetToken,
+		{ address, chainId, signer, pathname, host }: ISignToGetToken,
 		{ getState, dispatch },
 	) => {
 		try {
 			const siweMessage: any = await createSiweMessage(
 				address!,
 				chainId!,
-				pathname!,
+				host!,
 				'Login into Giveth services',
 			);
 			const { nonce, message } = siweMessage;

--- a/src/features/user/user.types.ts
+++ b/src/features/user/user.types.ts
@@ -3,4 +3,5 @@ export interface ISignToGetToken {
 	chainId?: number;
 	signer: any;
 	pathname?: string;
+	host?: string;
 }


### PR DESCRIPTION
In our current implementation the signToGetToken function will always be called on the client so we can get the host straight from the window, if for some reason in the future we call it from the server we can get the value from the req