### PR TITLE
last minute ux improvement

### DIFF
--- a/src/components/views/userProfile/UserProfile.view.tsx
+++ b/src/components/views/userProfile/UserProfile.view.tsx
@@ -32,9 +32,14 @@ import { useAppDispatch, useAppSelector } from '@/features/hooks';
 import { setShowSignWithWallet } from '@/features/modal/modal.slice';
 import UploadProfilePicModal from '@/components/modals/UploadProfilePicModal/UploadProfilePicModal';
 import { ProfileModal } from '@/lib/constants/Routes';
+import Routes from '@/lib/constants/Routes';
 import { removeQueryParamAndRedirect } from '@/helpers/url';
 import { useGiverPFPToken } from '@/hooks/useGiverPFPToken';
 import { EPFPSize, PFP } from '@/components/PFP';
+import { gqlRequest } from '@/helpers/requests';
+import { buildUsersPfpInfoQuery } from '@/lib/subgraph/pfpQueryBuilder';
+import { IGiverPFPToken } from '@/apollo/types/types';
+
 export enum EOrderBy {
 	TokenAmount = 'TokenAmount',
 	UsdAmount = 'UsdAmount',
@@ -56,7 +61,7 @@ const UserProfileView: FC<IUserProfileView> = ({ myAccount, user }) => {
 	const dispatch = useAppDispatch();
 	const { isSignedIn } = useAppSelector(state => state.user);
 	const { formatMessage } = useIntl();
-
+	const [pfpData, setPfpData] = useState<IGiverPFPToken[]>();
 	const { chainId } = useWeb3React();
 
 	const [showModal, setShowModal] = useState<boolean>(false); // follow this state to refresh user content on screen
@@ -83,6 +88,32 @@ const UserProfileView: FC<IUserProfileView> = ({ myAccount, user }) => {
 			removeQueryParamAndRedirect(router, ['modal']);
 		}
 	}, [router.query.modal]);
+
+	useEffect(() => {
+		const fetchPFPInfo = async (walletAddress: string) => {
+			try {
+				const query = buildUsersPfpInfoQuery([walletAddress]);
+				const { data } = await gqlRequest(
+					config.MAINNET_CONFIG.subgraphAddress,
+					false,
+					query,
+				);
+				if (
+					data[`user_${walletAddress}`] &&
+					data[`user_${walletAddress}`].length > 0
+				) {
+					setPfpData(data[`user_${walletAddress}`]);
+				}
+			} catch (e) {
+				console.error(e);
+			}
+		};
+		if (user?.walletAddress) {
+			fetchPFPInfo(user.walletAddress);
+			console.log(user.walletAddress);
+			console.log(pfpData);
+		}
+	}, [user]);
 
 	if (myAccount && !isSignedIn)
 		return (
@@ -147,24 +178,36 @@ const UserProfileView: FC<IUserProfileView> = ({ myAccount, user }) => {
 									</ExternalLink>
 								</AddressContainer>
 							</WalletContainer>
-							{pfpToken && (
-								<RaribleLinkContainer>
-									<a
-										href={
-											config.RARIBLE_ADDRESS +
-											'token/' +
-											pfpToken.id.replace('-', ':')
-										}
-										target='_blank'
-										rel='noreferrer'
-									>
+							{/* check pfp data, if truthy we check if user is looking at their account, 
+							based on this we show two different messages and links relating to pfp use on profile page  */}
+							{pfpData &&
+								(myAccount && pfpData !== undefined ? (
+									<RaribleLinkContainer>
 										<GLink>
-											View this Givers PFP on Rarible{' '}
-											<IconExternalLink16 />
+											<a href={Routes.MyAccountSetPfp}>
+												{' '}
+												Set your Givers PFP NFT{' '}
+											</a>
 										</GLink>
-									</a>
-								</RaribleLinkContainer>
-							)}
+									</RaribleLinkContainer>
+								) : (
+									<RaribleLinkContainer>
+										<a
+											href={
+												config.RARIBLE_ADDRESS +
+												'token/' +
+												pfpToken?.id.replace('-', ':')
+											}
+											target='_blank'
+											rel='noreferrer'
+										>
+											<GLink>
+												View this Givers PFP on Rarible{' '}
+												<IconExternalLink16 />
+											</GLink>
+										</a>
+									</RaribleLinkContainer>
+								))}
 						</UserInfoRow>
 					</UserInfo>
 				</Container>

--- a/src/components/views/userProfile/UserProfile.view.tsx
+++ b/src/components/views/userProfile/UserProfile.view.tsx
@@ -110,8 +110,6 @@ const UserProfileView: FC<IUserProfileView> = ({ myAccount, user }) => {
 		};
 		if (user?.walletAddress) {
 			fetchPFPInfo(user.walletAddress);
-			console.log(user.walletAddress);
-			console.log(pfpData);
 		}
 	}, [user]);
 

--- a/src/components/views/userProfile/UserProfile.view.tsx
+++ b/src/components/views/userProfile/UserProfile.view.tsx
@@ -181,7 +181,7 @@ const UserProfileView: FC<IUserProfileView> = ({ myAccount, user }) => {
 							{/* check pfp data, if truthy we check if user is looking at their account, 
 							based on this we show two different messages and links relating to pfp use on profile page  */}
 							{pfpData &&
-								(myAccount && pfpData !== undefined ? (
+								(myAccount && !pfpToken ? (
 									<RaribleLinkContainer>
 										<GLink>
 											<a href={Routes.MyAccountSetPfp}>


### PR DESCRIPTION
This was a last minute UX suggestion from @laurenluz 

If the user holds a Givers NFT in their wallet, is looking at their profile page and has not set a PFP as their profile picture we suggest them to do so and provide a direct link to the setProfilePic Modal. 

If the user does not hold a Givers PFP we show nothing

If the user is viewing any profile, including their own that has a pfp set already as their profile pic then we show a link to view it on Rarible. 