### PR TITLE
Accurate content length for Project Updates

### DIFF
--- a/src/components/RichTextInput.tsx
+++ b/src/components/RichTextInput.tsx
@@ -215,8 +215,7 @@ const TextRichWithQuill: FC<ITextRichWithQuillProps> = ({
 };
 
 const calcLengthOfHTML = (html: string) => {
-	const plainString = html.replace(/<[^>]+>/g, '');
-	return plainString.length;
+	return html.length;
 };
 interface IRichtextCounterProps {
 	value: string;

--- a/src/components/views/claim/cards/Donate.tsx
+++ b/src/components/views/claim/cards/Donate.tsx
@@ -34,7 +34,7 @@ import { IClaimViewCardProps } from '@/components/views/claim/Claim.view';
 import useClaim from '@/context/claim.context';
 import useGIVTokenDistroHelper from '@/hooks/useGIVTokenDistroHelper';
 import { IconWithTooltip } from '@/components/IconWithToolTip';
-import { InputWithUnit } from '@/components/input';
+import { InputWithUnit } from '@/components/input/index';
 import { Flex } from '@/components/styled-components/Flex';
 import { Zero, formatWeiHelper } from '@/helpers/number';
 


### PR DESCRIPTION
The length shown on the frontend isn't same as the length of the content being stored, as the frontend converts the HTML string to plain text.
fixes #2795 