### PR TITLE
fix: url in removeQueryParam

### DIFF
--- a/src/helpers/url.tsx
+++ b/src/helpers/url.tsx
@@ -88,7 +88,7 @@ export function removeQueryParam(
 	});
 	const newQuery = urlParams.toString();
 	if (fullURl) {
-		return newQuery ? `url?${newQuery}` : url;
+		return newQuery ? `${url}?${newQuery}` : url;
 	}
 	return newQuery ? `?${newQuery}` : '';
 }


### PR DESCRIPTION
related to #2635 

This doesn't solve the issue completely but it fixes a minor bug with the formatted string in `removeQueryParam`