### PR TITLE
Link to donor profile on project donations tab

### DIFF
--- a/src/components/UserWithPFPInCell.tsx
+++ b/src/components/UserWithPFPInCell.tsx
@@ -5,6 +5,8 @@ import { useGiverPFPToken } from '@/hooks/useGiverPFPToken';
 import { Flex } from '@/components/styled-components/Flex';
 import { shortenAddress } from '@/lib/helpers';
 import { PFP } from './PFP';
+import { addressToUserView } from '@/lib/routeCreators';
+import Link from 'next/link';
 
 interface IUserWithPFPInCell {
 	user: IAdminUser;
@@ -12,15 +14,16 @@ interface IUserWithPFPInCell {
 
 export const UserWithPFPInCell: FC<IUserWithPFPInCell> = ({ user }) => {
 	const pfpToken = useGiverPFPToken(user?.walletAddress, user?.avatar);
+	console.log(addressToUserView(user?.walletAddress?.toLowerCase()));
 	const name =
 		user?.name || shortenAddress(user?.walletAddress?.toLowerCase());
 	return pfpToken ? (
 		<Flex gap='12px' alignItems='center'>
 			<StyledPFP pfpToken={pfpToken} />
-			<Bold>{name || '\u200C'}</Bold>
+			<Link href={addressToUserView(user?.walletAddress?.toLowerCase())}>{name || '\u200C'} </Link>
 		</Flex>
 	) : (
-		<NoAvatar>{name || '\u200C'}</NoAvatar>
+		<NoAvatar><Link href={addressToUserView(user?.walletAddress?.toLowerCase())}>{name || '\u200C'} </Link></NoAvatar>
 	);
 };
 const StyledPFP = styled(PFP)`


### PR DESCRIPTION
fixes #612 

We should probably update the design for this a bit to make it more obvious that there ae two clickable in that components -> link to the block explorer for that transaction, and the user profile, instead of highlighting the whole component on hover...