### PR TITLE
HOTFIX:  Rewards count format is wrong for "exploited" pools on mainnet

### DIFF
--- a/src/components/menu/RewardItems.tsx
+++ b/src/components/menu/RewardItems.tsx
@@ -115,7 +115,7 @@ export const RewardItems: FC<IRewardItemsProps> = ({
 			);
 		}
 	}, [currentValues, chainId, givTokenDistroHelper]);
-	console.log({ farmsLiquidPart });
+
 	return (
 		<>
 			<Item theme={theme}>

--- a/src/components/menu/RewardItems.tsx
+++ b/src/components/menu/RewardItems.tsx
@@ -100,12 +100,14 @@ export const RewardItems: FC<IRewardItemsProps> = ({
 			let _farmRewards = constants.Zero;
 			pools.forEach(pool => {
 				if (pool.type !== StakingType.UNISWAPV3_ETH_GIV) {
-					_farmRewards = _farmRewards.add(
-						getUserStakeInfo(
-							currentValues,
-							pool as SimplePoolStakingConfig,
-						).earned,
-					);
+					if (!pool?.exploited) {
+						_farmRewards = _farmRewards.add(
+							getUserStakeInfo(
+								currentValues,
+								pool as SimplePoolStakingConfig,
+							).earned,
+						);
+					}
 				}
 			});
 			setFarmsLiquidPart(
@@ -113,6 +115,7 @@ export const RewardItems: FC<IRewardItemsProps> = ({
 			);
 		}
 	}, [currentValues, chainId, givTokenDistroHelper]);
+	console.log({ farmsLiquidPart });
 	return (
 		<>
 			<Item theme={theme}>


### PR DESCRIPTION
As reported by @divine-comedian the rewards amount would be wrong

![image](https://github.com/Giveth/giveth-dapps-v2/assets/18689480/49904701-bb40-46f5-967f-e82c3e12306f)

I noticed the graph is showing wrong formats as well, maybe because of the pool being inactive for a while now

![image](https://github.com/Giveth/giveth-dapps-v2/assets/18689480/4d8d46ec-cf60-4545-aabf-af4252fe09c1)

