### PR TITLE
Add .yarnrc.yml to specify which yarn version

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,0 +1,1 @@
+yarnPath: ".yarn/releases/yarn-1.22.19.js"


### PR DESCRIPTION
Ensures right version for Giveth, simplifies for new developers that have yarn 2+ as their default version.