### PR TITLE
Hotfix set sentry filter for other env

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "givethdapp",
-	"version": "2.22",
+	"version": "2.22.1",
 	"private": true,
 	"scripts": {
 		"build": "next build",

--- a/sentry.client.config.js
+++ b/sentry.client.config.js
@@ -15,7 +15,7 @@ Sentry.init({
 	// Note: if you want to override the automatic release value, do not set a
 	// `release` value here - use the environment variable `SENTRY_RELEASE`, so
 	// that it will also get attached to your source maps
-	beforeSend(event, hint) {
+	beforeSend(event) {
 		if (event.tags.section === SENTRY_URGENT) {
 			return event;
 		} else {

--- a/sentry.edge.config.js
+++ b/sentry.edge.config.js
@@ -1,0 +1,25 @@
+// This file configures the initialization of Sentry on the server.
+// The config you add here will be used whenever the server handles a request.
+// https://docs.sentry.io/platforms/javascript/guides/nextjs/
+
+import * as Sentry from '@sentry/nextjs';
+import { SENTRY_URGENT } from '@/configuration';
+
+const SENTRY_DSN = process.env.NEXT_PUBLIC_SENTRY_DSN;
+
+Sentry.init({
+	dsn: SENTRY_DSN,
+	// Adjust this value in production, or use tracesSampler for greater control
+	tracesSampleRate: 1.0,
+	// ...
+	// Note: if you want to override the automatic release value, do not set a
+	// `release` value here - use the environment variable `SENTRY_RELEASE`, so
+	// that it will also get attached to your source maps
+	beforeSend(event) {
+		if (event.tags.section === SENTRY_URGENT) {
+			return event;
+		} else {
+			return null;
+		}
+	},
+});

--- a/sentry.server.config.js
+++ b/sentry.server.config.js
@@ -3,6 +3,7 @@
 // https://docs.sentry.io/platforms/javascript/guides/nextjs/
 
 import * as Sentry from '@sentry/nextjs';
+import { SENTRY_URGENT } from '@/configuration';
 
 const SENTRY_DSN = process.env.NEXT_PUBLIC_SENTRY_DSN;
 
@@ -14,4 +15,11 @@ Sentry.init({
 	// Note: if you want to override the automatic release value, do not set a
 	// `release` value here - use the environment variable `SENTRY_RELEASE`, so
 	// that it will also get attached to your source maps
+	beforeSend(event) {
+		if (event.tags.section === SENTRY_URGENT) {
+			return event;
+		} else {
+			return null;
+		}
+	},
 });


### PR DESCRIPTION
Regarding Sentry, according to the [documentation](https://docs.sentry.io/platforms/javascript/configuration/filtering/), we can filter logs using the `beforeSend` hook. I've pushed a hotfix to filter older client logs, and this hotfix extends to filtering edge and server logs as well. Hopefully, this resolves the issue, and we'll only receive urgent errors going forward.
- #3584 