### PR TITLE
fix: modify archived QF rounds page UI

### DIFF
--- a/src/apollo/gql/gqlQF.ts
+++ b/src/apollo/gql/gqlQF.ts
@@ -10,6 +10,8 @@ export const FETCH_QF_ROUNDS_QUERY = `
 			beginDate
 			endDate
 			minimumPassportScore
+			bannerBgImage
+			sponsorsImgs
 		}
 	}
 `;

--- a/src/apollo/types/types.ts
+++ b/src/apollo/types/types.ts
@@ -466,6 +466,8 @@ export interface IQFRound {
 	minimumPassportScore: number;
 	eligibleNetworks: number[];
 	maximumReward: number;
+	bannerBgImage: string;
+	sponsorsImgs: string[];
 }
 
 export interface IGetQfRoundHistory {

--- a/src/components/views/projects/ProjectsIndex.tsx
+++ b/src/components/views/projects/ProjectsIndex.tsx
@@ -39,6 +39,7 @@ import { SortContainer } from './sort/SortContainer';
 import { ArchivedQFRoundStats } from './ArchivedQFRoundStats';
 import { ArchivedQFProjectsBanner } from './qfBanner/ArchivedQFProjectsBanner';
 import { ActiveQFRoundStats } from './ActiveQFRoundStats';
+import useMediaQuery from '@/hooks/useMediaQuery';
 
 export interface IProjectsView {
 	projects: IProject[];
@@ -59,6 +60,7 @@ const ProjectsIndex = (props: IProjectsView) => {
 	const [filteredProjects, setFilteredProjects] =
 		useState<IProject[]>(projects);
 	const [totalCount, setTotalCount] = useState(_totalCount);
+	const isMobile = useMediaQuery(`(max-width: ${deviceSize.tablet - 1}px)`);
 
 	const dispatch = useAppDispatch();
 
@@ -211,7 +213,7 @@ const ProjectsIndex = (props: IProjectsView) => {
 					<ActiveQFProjectsBanner />
 				</>
 			) : isArchivedQF ? (
-				<ArchivedQFProjectsBanner />
+				!isMobile && <ArchivedQFProjectsBanner />
 			) : (
 				<ProjectsBanner mainCategory={selectedMainCategory} />
 			)}

--- a/src/components/views/projects/qfBanner/ArchivedQFProjectsBanner.tsx
+++ b/src/components/views/projects/qfBanner/ArchivedQFProjectsBanner.tsx
@@ -1,62 +1,233 @@
-import { Container, H2, Row } from '@giveth/ui-design-system';
+import { Container, H2, Row, H1 } from '@giveth/ui-design-system';
 import Image from 'next/image';
 import { useIntl } from 'react-intl';
 import { useRouter } from 'next/router';
-import {
-	BannerContainer,
-	ImgTopRight,
-	ImgBottomRight,
-	ImgTopLeft,
-	ImgBottomLeft,
-	StyledCol,
-	Title,
-} from './common';
+import styled from 'styled-components';
+import { BannerContainer, StyledColArch } from './common';
 import { useProjectsContext } from '@/context/projects.context';
+import useMediaQuery from '@/hooks/useMediaQuery';
+import { deviceSize } from '@/lib/constants/constants';
+
+type TImgDimensionsMap = {
+	[key: number]: { desktop: number; tablet: number; gridColumns: number };
+};
 
 export const ArchivedQFProjectsBanner = () => {
 	const { formatMessage } = useIntl();
 	const { query } = useRouter();
 	const { qfRounds } = useProjectsContext();
 	const round = qfRounds.find(round => round.slug === query.slug);
+	const sponsorsLength = round?.sponsorsImgs?.length ?? 0;
+	const imgDimensionsMap: TImgDimensionsMap = {
+		1: { desktop: 300, tablet: 260, gridColumns: 1 },
+		2: { desktop: 200, tablet: 160, gridColumns: 2 },
+		4: { desktop: 150, tablet: 110, gridColumns: 2 },
+		5: { desktop: 120, tablet: 100, gridColumns: 3 },
+		6: { desktop: 100, tablet: 80, gridColumns: 3 },
+	};
+	const islaptopS = useMediaQuery(`(max-width: ${deviceSize.laptopS - 1}px)`);
+
+	const render3SponsorsGrid = () => {
+		if (!round || !round.sponsorsImgs || round.sponsorsImgs.length !== 3) {
+			return null;
+		}
+
+		const [sponsor1, sponsor2, sponsor3] = round.sponsorsImgs;
+
+		return (
+			<CardGrid>
+				<TopLeftCard>
+					<Image
+						width={140}
+						height={140}
+						layout='fixed'
+						objectFit='cover'
+						src={sponsor1}
+						alt='Sponsor 1'
+					/>
+				</TopLeftCard>
+				<TopRightCard>
+					<Image
+						width={140}
+						height={140}
+						layout='fixed'
+						objectFit='cover'
+						src={sponsor2}
+						alt='Sponsor 2'
+					/>
+				</TopRightCard>
+				<BottomCenterCard>
+					<Image
+						width={140}
+						height={140}
+						layout='fixed'
+						objectFit='cover'
+						src={sponsor3}
+						alt='Sponsor 3'
+					/>
+				</BottomCenterCard>
+			</CardGrid>
+		);
+	};
 
 	return (
 		<BannerContainer>
-			<Image
-				src={'/images/banners/qf-round/bg.svg'}
-				style={{ objectFit: 'cover' }}
-				fill
-				alt='QF Banner'
-			/>
-			<ImgTopRight
-				src={'/images/banners/qf-round/top-right.png'}
-				style={{ objectFit: 'cover' }}
-				alt='QF OP'
-			/>
-			<ImgBottomRight
-				src={'/images/banners/qf-round/bottom-right.svg'}
-				style={{ objectFit: 'cover' }}
-				alt='QF OP'
-			/>
-			<ImgTopLeft
-				src={'/images/banners/qf-round/top-left.svg'}
-				style={{ objectFit: 'cover' }}
-				alt='QF OP'
-			/>
-			<ImgBottomLeft
-				src={'/images/banners/qf-round/bottom-left.png'}
-				style={{ objectFit: 'cover' }}
-				alt='QF OP'
-			/>
-			<Container>
-				<Row>
-					<StyledCol xs={12} md={12}>
-						<Title weight={700}>
-							{formatMessage({ id: 'label.quadratic_funding' })}
-						</Title>
-						<H2>{round ? round.name : null}</H2>
-					</StyledCol>
-				</Row>
-			</Container>
+			{round?.bannerBgImage && (
+				<Image
+					src={round?.bannerBgImage}
+					style={{ objectFit: 'cover' }}
+					fill
+					alt='QF Banner'
+				/>
+			)}
+			<ContentContainer>
+				<BannnerTitleContainer>
+					<Row>
+						<StyledColArch
+							xs={12}
+							md={12}
+							style={
+								round && round.name
+									? { flexDirection: 'column' }
+									: { flexDirection: 'row' }
+							}
+						>
+							<H1 weight={700}>
+								{formatMessage({
+									id: 'label.quadratic_funding',
+								})}
+							</H1>
+							<H2>
+								{round ? round.name : null}{' '}
+								{islaptopS ? 'Tablet' : 'Desktop'}
+							</H2>
+						</StyledColArch>
+					</Row>
+				</BannnerTitleContainer>
+				{sponsorsLength === 3 ? (
+					render3SponsorsGrid()
+				) : round && sponsorsLength > 0 ? (
+					<SponsorsContainer
+						style={{
+							gridTemplateColumns: `repeat(${imgDimensionsMap[sponsorsLength].gridColumns}, 1fr)`,
+						}}
+					>
+						{round.sponsorsImgs.map((sponsor, index) => (
+							<SingleSponsorImgContainer
+								key={`sponsor_${index + 1}`}
+								style={{
+									width:
+										imgDimensionsMap[sponsorsLength][
+											islaptopS ? 'tablet' : 'desktop'
+										] + 'px',
+									height:
+										imgDimensionsMap[sponsorsLength][
+											islaptopS ? 'tablet' : 'desktop'
+										] + 'px',
+								}}
+							>
+								<Image
+									src={sponsor}
+									alt={`Sponsor ${index}`}
+									width={
+										imgDimensionsMap[sponsorsLength][
+											islaptopS ? 'tablet' : 'desktop'
+										]
+									}
+									height={
+										imgDimensionsMap[sponsorsLength][
+											islaptopS ? 'tablet' : 'desktop'
+										]
+									}
+									layout='fixed'
+									objectFit='cover'
+								/>
+							</SingleSponsorImgContainer>
+						))}
+					</SponsorsContainer>
+				) : null}
+			</ContentContainer>
 		</BannerContainer>
 	);
 };
+
+const CardGrid = styled.div`
+	display: grid;
+	grid-template-columns: 1fr 1fr;
+	grid-template-rows: auto auto;
+	gap: 20px;
+`;
+
+const Card = styled.div`
+	position: relative;
+	background-color: #f0f0f0;
+	box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+	height: 140px;
+	width: 140px;
+	border-radius: 20px;
+	overflow: hidden;
+
+	@media (max-width: 1024px) {
+		width: 100px;
+		height: 100px;
+	}
+`;
+
+const TopLeftCard = styled(Card)`
+	grid-column: 1 / span 1;
+	grid-row: 1 / span 1;
+`;
+
+const TopRightCard = styled(Card)`
+	grid-column: 2 / span 1;
+	grid-row: 1 / span 1;
+`;
+
+const BottomCenterCard = styled(Card)`
+	grid-column: 1 / span 2;
+	grid-row: 2 / span 1;
+	justify-self: center;
+`;
+
+const ContentContainer = styled(Container)`
+	display: flex;
+	justify-content: space-between;
+	align-items: center;
+	position: relative;
+	z-index: 1;
+	padding: 0 20px;
+
+	@media (max-width: 1024px) {
+		width: 90% !important;
+	}
+`;
+
+const BannnerTitleContainer = styled.div`
+	position: relative;
+	z-index: 1;
+`;
+
+const SponsorsContainer = styled.div`
+	display: grid;
+	justify-content: center;
+	align-items: center;
+	grid-template-columns: repeat(3, 1fr);
+	gap: 20px;
+
+	@media (max-width: 1024px) {
+		gap: 10px;
+	}
+`;
+
+const SingleSponsorImgContainer = styled.div`
+	position: relative;
+	width: 140px;
+	height: 140px;
+	border-radius: 20px;
+	overflow: hidden;
+
+	@media (max-width: 1024px) {
+		width: 100px;
+		height: 100px;
+	}
+`;

--- a/src/components/views/projects/qfBanner/common.ts
+++ b/src/components/views/projects/qfBanner/common.ts
@@ -138,3 +138,14 @@ export const Sponsor = styled(Image)`
 		height: 188px;
 	}
 `;
+
+export const StyledColArch = styled(Col)`
+	position: relative;
+	display: flex;
+	justify-content: center;
+	align-items: center;
+	z-index: 1;
+	min-height: 300px;
+	text-align: center;
+	color: #ffffff;
+`;


### PR DESCRIPTION
Related to #3250 

- add sponsors images array and banner image to retrieved graphQL fields
- display images based on the design https://www.figma.com/file/C3HykACu0eNImhAqu0our8/Giveth-projects?type=design&node-id=5897-26523&mode=design&t=VVFxkFuZMTDzkM6A-0