### PR TITLE
Update next.config.js

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -22,6 +22,7 @@ const moduleExports = withBundleAnalyzer({
 			{ protocol: 'https', port: '', hostname: 'giveth.mypinata.cloud' },
 			{ protocol: 'https', port: '', hostname: 'static.tgbwidget.com' },
 			{ protocol: 'https', port: '', hostname: 'images.unsplash.com' },
+			{ protocol: 'https', port: '', hostname: 'unicorn.mypinata.cloud' },
 			{
 				protocol: 'https',
 				port: '',


### PR DESCRIPTION
allow new ipfs pinned images endpoint. 

A new endpoint was assigned to our pinata and this is causing some images to break.. 

![image](https://github.com/Giveth/giveth-dapps-v2/assets/67759413/e36306bd-fd6a-45cb-b74f-26c181de8d81)
