### PR TITLE
Fixing QF eligible chains message is incorrect

### DIFF
--- a/src/components/views/donate/QFModal.tsx
+++ b/src/components/views/donate/QFModal.tsx
@@ -21,8 +21,11 @@ const QFModal: FC<IProps> = ({ setShowModal, donateWithoutMatching }) => {
 	const { project } = useDonateData();
 	const { activeStartedRound } = getActiveRound(project.qfRounds);
 	const roundName = activeStartedRound?.name;
-	const eligibleChainName = getChainName(
-		activeStartedRound?.eligibleNetworks[0],
+
+	const eligibleChainName = activeStartedRound?.eligibleNetworks.map(
+		network => {
+			return getChainName(network);
+		},
 	);
 
 	return (
@@ -39,7 +42,7 @@ const QFModal: FC<IProps> = ({ setShowModal, donateWithoutMatching }) => {
 					{formatMessage({
 						id: 'label.your_donation_can_qualify_for_matching_1',
 					})}
-					<span> {eligibleChainName} </span>
+					<span> {eligibleChainName?.join(' & ')} </span>
 					{formatMessage({
 						id: 'label.your_donation_can_qualify_for_matching_2',
 					})}


### PR DESCRIPTION
Fix #4123 

There was problem in QF modal message it was showing only one eligible network, changed code to show all eligible networks.

@MohammadPCh, cc @jainkrati please check this when you get time.

Also @divine-comedian, I tested on same project with same steps that you mentioned and result is:

![Screenshot_2024-05-15_at_10 58 18](https://github.com/Giveth/giveth-dapps-v2/assets/1242145/1b59c928-19dd-4587-b3ef-658d6c28989b)


