### PR TITLE
replace sumDonationValueUsd with totalDonations, remove refs

### DIFF
--- a/src/apollo/gql/gqlProjects.ts
+++ b/src/apollo/gql/gqlProjects.ts
@@ -48,7 +48,6 @@ export const PROJECT_CARD_FIELDS = gql`
 			round
 		}
 		sumDonationValueUsdForActiveQfRound
-		sumDonationValueUsd
 		countUniqueDonorsForActiveQfRound
 		countUniqueDonors
 		estimatedMatching {
@@ -147,7 +146,6 @@ export const FETCH_PROJECT_BY_SLUG_DONATION = gql`
 			slug
 			descriptionSummary
 			verified
-			sumDonationValueUsd
 			sumDonationValueUsdForActiveQfRound
 			countUniqueDonorsForActiveQfRound
 			adminUser {
@@ -261,7 +259,6 @@ export const FETCH_PROJECT_BY_SLUG_SINGLE_PROJECT = gql`
 			}
 			givbackFactor
 			sumDonationValueUsdForActiveQfRound
-			sumDonationValueUsd
 			countUniqueDonorsForActiveQfRound
 			countUniqueDonors
 			estimatedMatching {

--- a/src/apollo/types/types.ts
+++ b/src/apollo/types/types.ts
@@ -77,7 +77,6 @@ export interface IProject {
 	countUniqueDonors?: number;
 	countUniqueDonorsForActiveQfRound?: number;
 	estimatedMatching: IEstimatedMatching;
-	sumDonationValueUsd?: number;
 	sumDonationValueUsdForActiveQfRound?: number;
 	qfRounds?: IQFRound[];
 	campaigns?: ICampaign[];

--- a/src/components/project-card/ProjectCard.tsx
+++ b/src/components/project-card/ProjectCard.tsx
@@ -52,7 +52,7 @@ const ProjectCard = (props: IProjectCard) => {
 		image,
 		slug,
 		adminUser,
-		sumDonationValueUsd,
+		totalDonations,
 		sumDonationValueUsdForActiveQfRound,
 		updatedAt,
 		organization,
@@ -172,7 +172,7 @@ const ProjectCard = (props: IProjectCard) => {
 								{formatDonation(
 									(activeStartedRound
 										? sumDonationValueUsdForActiveQfRound
-										: sumDonationValueUsd) || 0,
+										: totalDonations) || 0,
 									'$',
 									locale,
 								)}
@@ -190,7 +190,7 @@ const ProjectCard = (props: IProjectCard) => {
 										}) + ' '}
 										<span>
 											{formatDonation(
-												sumDonationValueUsd || 0,
+												totalDonations || 0,
 												'$',
 												locale,
 											)}

--- a/src/components/views/donate/DonatePageProjectDescription.tsx
+++ b/src/components/views/donate/DonatePageProjectDescription.tsx
@@ -30,7 +30,7 @@ export const DonatePageProjectDescription: FC<
 > = ({ projectData, showRaised = true }) => {
 	const { formatMessage, locale } = useIntl();
 	const {
-		sumDonationValueUsd,
+		totalDonations,
 		slug,
 		title,
 		descriptionSummary,
@@ -64,7 +64,7 @@ export const DonatePageProjectDescription: FC<
 			{showRaised && (
 				<P>
 					{formatMessage({ id: 'label.raised' })}:{' '}
-					{formatDonation(sumDonationValueUsd || 0, '$', locale)}
+					{formatDonation(totalDonations || 0, '$', locale)}
 				</P>
 			)}
 			<DescriptionSummary>{descriptionSummary}</DescriptionSummary>

--- a/src/components/views/project/projectActionCard/DonationSection.tsx
+++ b/src/components/views/project/projectActionCard/DonationSection.tsx
@@ -25,19 +25,19 @@ interface IDonateSectionProps {
 
 export const DonateSection: FC<IDonateSectionProps> = ({ projectData }) => {
 	const { formatMessage, locale } = useIntl();
-	const { sumDonationValueUsd } = projectData || {};
+	const { totalDonations } = projectData || {};
 	const isMobile = !useMediaQuery(device.tablet);
 
 	return (
 		<DonationSectionWrapper gap='24px'>
-			{sumDonationValueUsd && sumDonationValueUsd !== 0 ? (
+			{totalDonations && totalDonations !== 0 ? (
 				<DonateInfo>
 					{isMobile && <br />}
 					<Title>
 						{formatMessage({ id: 'label.total_amount_raised' })}
 					</Title>
 					<Amount weight={700}>
-						{formatDonation(sumDonationValueUsd || 0, '$', locale)}
+						{formatDonation(totalDonations || 0, '$', locale)}
 					</Amount>
 					<Description>
 						{formatMessage({

--- a/src/components/views/project/projectActionCard/QFSection.tsx
+++ b/src/components/views/project/projectActionCard/QFSection.tsx
@@ -46,7 +46,7 @@ const QFSection: FC<IQFSectionProps> = ({ projectData }) => {
 		qfRounds,
 		estimatedMatching,
 		sumDonationValueUsdForActiveQfRound,
-		sumDonationValueUsd,
+		totalDonations,
 		adminUser,
 		slug,
 		organization,
@@ -136,7 +136,7 @@ const QFSection: FC<IQFSectionProps> = ({ projectData }) => {
 							})}
 							{' ' +
 								formatDonation(
-									sumDonationValueUsd || 0,
+									totalDonations || 0,
 									'$',
 									locale,
 								)}
@@ -188,7 +188,7 @@ const QFSection: FC<IQFSectionProps> = ({ projectData }) => {
 							})}
 							{' ' +
 								formatDonation(
-									sumDonationValueUsd || 0,
+									totalDonations || 0,
 									'$',
 									locale,
 								)}

--- a/src/components/views/userProfile/projectsTab/ProjectItem.tsx
+++ b/src/components/views/userProfile/projectsTab/ProjectItem.tsx
@@ -124,7 +124,7 @@ const ProjectItem = ({ project, setProjects }: IProjectItem) => {
 							</Flex>
 						</P>
 						{formatDonation(
-							project.sumDonationValueUsd || 0,
+							project.totalDonations || 0,
 							'$',
 							locale,
 						)}


### PR DESCRIPTION
replace sumDonationValueUsd with totalDonations, remove references in FE ahead of deprecation of variable in BE

ref: https://github.com/Giveth/impact-graph/issues/1566

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Renamed `sumDonationValueUsd` to `totalDonations` across various components and queries for consistency.

- **Bug Fixes**
  - Updated display of donation values to reflect the new `totalDonations` field.

- **Chores**
  - Removed the `sumDonationValueUsd` field from GraphQL queries and types to streamline data handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->