### PR TITLE
fix: show unique donors as pending 

### DIFF
--- a/src/apollo/gql/gqlQF.ts
+++ b/src/apollo/gql/gqlQF.ts
@@ -71,6 +71,7 @@ export const FETCH_ARCHIVED_QF_ROUNDS = gql`
 			endDate
 			totalDonations
 			uniqueDonors
+			isDataAnalysisDone
 		}
 	}
 `;

--- a/src/apollo/types/types.ts
+++ b/src/apollo/types/types.ts
@@ -478,6 +478,7 @@ export interface IQFRound {
 export interface IArchivedQFRound extends IQFRound {
 	totalDonations: number;
 	uniqueDonors: number;
+	isDataAnalysisDone: boolean;
 }
 
 export interface IGetQfRoundHistory {

--- a/src/components/views/archivedQFRounds/ArchivedQFRoundsTable.tsx
+++ b/src/components/views/archivedQFRounds/ArchivedQFRoundsTable.tsx
@@ -33,7 +33,7 @@ export const ArchivedQFRoundsTable: FC<ArchivedQFRoundsTableProps> = ({
 					<StyledGLink size='Big'>Round Duration</StyledGLink>
 					<StyledGLink size='Big'></StyledGLink>
 				</TH>
-				{archivedQFRounds.map((round, index) => (
+				{archivedQFRounds.map(round => (
 					<TR key={round.id}>
 						<P>{round.name}</P>
 						<P>
@@ -46,7 +46,13 @@ export const ArchivedQFRoundsTable: FC<ArchivedQFRoundsTableProps> = ({
 							</Flex>
 						</P>
 						<P>{formatDonation(round.totalDonations, '$') || 0}</P>
-						<P>{round.uniqueDonors}</P>
+						<P>
+							{round.isDataAnalysisDone ? (
+								round.uniqueDonors
+							) : (
+								<AnalysisStatus>Pending</AnalysisStatus>
+							)}
+						</P>
 						<Flex $flexDirection='column'>
 							<P>{formatDate(new Date(round.beginDate))}</P>
 							<P>{formatDate(new Date(round.endDate))}</P>
@@ -131,4 +137,8 @@ const StyledGLink = styled(GLink)`
 	white-space: nowrap;
 	text-overflow: ellipsis;
 	overflow: hidden;
+`;
+
+const AnalysisStatus = styled(P)`
+	color: ${neutralColors.gray[600]};
 `;


### PR DESCRIPTION
Related to #4245 

- Show unique donors as pending when data analysis is not done for listed archived QF rounds

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced the archived QF rounds table to display analysis status. It now shows "Pending" if data analysis is not done.
  
- **Improvements**
  - Updated the interface for archived QF rounds to include the data analysis status, providing better context for users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->