### PR TITLE
Fixed missing "Y" in word on creating new project

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -60,7 +60,7 @@
 	"component.pro_guide.tips.address.item3": "Adding a recipient address on multiple chains will increase your exposure to potential donors.",
 	"component.pro_guide.tips.address.item4": "You can update your recipient addresses at any time.",
 	"component.pro_guide.tips.social_media.item1": "Adding your social media accounts allows your donors and community to connect with you and learn what you are up to!",
-	"component.pro_guide.tips.social_media.item2": "our accounts will be linked to from your project's page on Giveth.",
+	"component.pro_guide.tips.social_media.item2": "Your accounts will be linked to from your project's page on Giveth.",
 	"component.pro_guide.tips.social_media.item3": "Giveth might use your social media handles to contact you or tag you on posts to support your fundraising.",
 	"component.qf-section.tooltip": "This estimation is the matching funds that this project would get if the round ended now, disregarding fraud analysis.",
 	"component.qf-section.tooltip_polygon": "This estimate represents the matching funds this project would receive if the round closed now, ignoring the fraud analysis.",


### PR DESCRIPTION
Fix #4263

There is first letter "Y" missing in helpful tips.

@MohammadPCh it is fixed ;)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected a grammatical error in a tooltip related to social media accounts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->