### PR TITLE
fix: remove mid banner from archived QF table page

### DIFF
--- a/src/components/views/archivedQFRounds/ArchivedQFRounds.view.tsx
+++ b/src/components/views/archivedQFRounds/ArchivedQFRounds.view.tsx
@@ -5,7 +5,6 @@ import { QFHeader } from './QFHeader';
 import { client } from '@/apollo/apolloClient';
 import { IArchivedQFRound } from '@/apollo/types/types';
 import { ArchivedQFRoundsTable } from './ArchivedQFRoundsTable';
-import { ArchivedQFRoundsMiddleBanner } from './ArchivedQFRoundsMiddleBanner';
 import { FETCH_ARCHIVED_QF_ROUNDS } from '@/apollo/gql/gqlQF';
 import { useArchivedQFRounds } from './archivedQfRounds.context';
 import { EQFRoundsSortBy } from '@/apollo/types/gqlEnums';
@@ -111,21 +110,10 @@ export const ArchivedQFRoundsView = () => {
 					<ArchivedQFRoundsSort />
 				</HeaderWrapper>
 
-				<ArchivedQFRoundsTable
-					archivedQFRounds={archivedQFRounds.slice(0, 5)}
-				/>
+				<ArchivedQFRoundsTable archivedQFRounds={archivedQFRounds} />
 				{archivedQFRounds.length == 0 && loading && (
 					<WrappedSpinner size={100} />
 				)}
-			</Container>
-			<ArchivedQFRoundsMiddleBanner />
-			<Container>
-				<ArchivedQFRoundsTable
-					archivedQFRounds={archivedQFRounds.slice(
-						5,
-						archivedQFRounds.length,
-					)}
-				/>
 			</Container>
 			{archivedQFRounds.length > 0 && loading ? (
 				<WrappedSpinner size={100} />


### PR DESCRIPTION
Related to https://github.com/Giveth/giveth-dapps-v2/issues/3748#issuecomment-2159281578

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Simplified the display logic for archived QF rounds.
  
- **Removed**
	- Removed the `ArchivedQFRoundsMiddleBanner` component.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->