### PR TITLE
fix: keep minimumValidUsdValue field only on FETCH_PROJECT_BY_SLUG_DO…

### DIFF
--- a/src/apollo/gql/gqlProjects.ts
+++ b/src/apollo/gql/gqlProjects.ts
@@ -19,7 +19,6 @@ export const PROJECT_CORE_FIELDS = gql`
 			allocatedTokenSymbol
 			allocatedFundUSDPreferred
 			allocatedFundUSD
-			minimumValidUsdValue
 		}
 	}
 `;
@@ -279,7 +278,6 @@ export const FETCH_PROJECT_BY_SLUG_SINGLE_PROJECT = gql`
 				allocatedTokenSymbol
 				allocatedFundUSDPreferred
 				allocatedFundUSD
-				minimumValidUsdValue
 			}
 			campaigns {
 				id

--- a/src/apollo/types/types.ts
+++ b/src/apollo/types/types.ts
@@ -473,7 +473,7 @@ export interface IQFRound {
 	allocatedFundUSDPreferred: boolean;
 	allocatedTokenSymbol: string;
 	allocatedTokenChainId: number;
-	minimumValidUsdValue: number;
+	minimumValidUsdValue?: number;
 }
 
 export interface IArchivedQFRound extends IQFRound {


### PR DESCRIPTION
…NATION query

Related to #3829

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Removed the `minimumValidUsdValue` field from project data queries to simplify the data structure.

- **Bug Fixes**
  - Made the `minimumValidUsdValue` property optional in the `IQFRound` interface for better flexibility and to handle potential null values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->