### PR TITLE
fix: change estimated matching to a range

### DIFF
--- a/lang/ca.json
+++ b/lang/ca.json
@@ -1253,7 +1253,7 @@
 	"page.about_us.desc.one": "Giveth és una comunitat centrada en la construcció del Futur de les Donacions utilitzant la tecnologia blockchain. La nostra intenció és donar suport i recompensar la finançament de béns públics creant accés obert, transparent i gratuït a les oportunitats de finançament innovadores en l'ecosistema d'Ethereum.",
 	"page.about_us.desc.two": "Giveth està construint una cultura de donació que capacita i recompensa als qui donen, als projectes, a la societat i al món. El nostre objectiu és inspirar la nostra comunitat a participar en un ecosistema de suport col·lectiu, d'abundància i de creació de valor. Comproveu el nostre",
 	"page.donate.bank_fees": "Comissions Bancàries",
-	"page.donate.matching_toast.bottom_valid": "Els fons d'emparellament s'enviaran al projecte seleccionat després que acabi la ronda.",
+	"page.donate.matching_toast.bottom_valid": "Els fons de finançament es destinaran al projecte seleccionat després que acabi la ronda. Dona a més projectes per rebre més finançament!",
 	"page.donate.matching_toast.bottom_invalid_p1": "Només donacions de més de",
 	"page.donate.matching_toast.bottom_invalid_p2": "són elegibles per a l'aparellament.",
 	"page.donate.matching_toast.upper_valid": "Emparellament estimat",

--- a/lang/en.json
+++ b/lang/en.json
@@ -1253,7 +1253,7 @@
 	"page.about_us.desc.one": "Giveth is a community focused on Building the Future of Giving using blockchain technology. Our intention is to support and reward the funding of public goods by creating open, transparent and free access to the revolutionary funding opportunities available within the Ethereum ecosystem.",
 	"page.about_us.desc.two": "Giveth is building a culture of giving that empowers and rewards those who give -- to projects, to society, and to the world. We aim to inspire our community to participate in an ecosystem of collective support, abundance and value-creation. Check out our",
 	"page.donate.bank_fees": "Bank Fees",
-	"page.donate.matching_toast.bottom_valid": "Matching funds will be sent to the selected project after the round ends.",
+	"page.donate.matching_toast.bottom_valid": "Matching funds will be sent to the selected project after the round ends. Donate to more projects to receive higher matching!",
 	"page.donate.matching_toast.bottom_invalid_p1": "Only donations more than",
 	"page.donate.matching_toast.bottom_invalid_p2": "are eligible for matching.",
 	"page.donate.matching_toast.upper_valid": "Estimated matching",

--- a/lang/es.json
+++ b/lang/es.json
@@ -1253,7 +1253,7 @@
 	"page.about_us.desc.one": "Giveth es una comunidad enfocada en construir el Futuro de las Donaciones utilizando la tecnología blockchain. Nuestra intención es apoyar y recompensar la financiación de bienes públicos creando un acceso abierto, transparente y gratuito a las oportunidades de financiación innovadoras en el ecosistema de Ethereum.",
 	"page.about_us.desc.two": "Giveth está construyendo una cultura de donación que empodera y recompensa a los que donan, a los proyectos, a la sociedad y al mundo. Nuestro objetivo es inspirar a nuestra comunidad a participar en un ecosistema de apoyo colectivo, de abundancia y creación de valor. Echa un vistazo a nuestro",
 	"page.donate.bank_fees": "Comisiones Bancarias",
-	"page.donate.matching_toast.bottom_valid": "Los fondos complementarios se enviarán al proyecto seleccionado después de que termine la ronda.",
+	"page.donate.matching_toast.bottom_valid": "Los fondos de emparejamiento se enviarán al proyecto seleccionado después de que termine la ronda. ¡Dona a más proyectos para recibir un mayor emparejamiento!",
 	"page.donate.matching_toast.bottom_invalid_p1": "Sólo las donaciones superiores a",
 	"page.donate.matching_toast.bottom_invalid_p2": "son subvencionables.",
 	"page.donate.matching_toast.upper_valid": "Estimado del monto complementado",

--- a/lang/t_ca.json
+++ b/lang/t_ca.json
@@ -145,7 +145,7 @@
 	"label.you_can_view_them_on_a_blockchain_explorer_here": "Pots veure-les en un explorador de blocs aquí:",
 	"other": "Altres",
 	"other_desc": " ",
-	"page.donate.matching_toast.bottom_valid": "Els fons de coincidència es enviaran al projecte seleccionat quan acabi la ronda.",
+	"page.donate.matching_toast.bottom_valid": "Els fons de finançament es destinaran al projecte seleccionat després que acabi la ronda. Dona a més projectes per rebre més finançament!",
 	"page.donate.matching_toast.upper_valid": "Coincidència estimada",
 	"page.donate.passport_toast.description.eligible": "La teva donació és elegible per ser coincidida! Després de la",
 	"page.donate.passport_toast.description.eligible_2": ", totes les donacions seran revisades per a la protecció contra el frau i els fons de coincidència es enviaran als projectes. Estigueu atents a les notificacions :)",
@@ -170,5 +170,5 @@
 	"project.givback_toast.title.verified_public_2": " del valor de la teva donació!",
 	"refi": "Refi",
 	"testfilter": "testfilter",
-	"tooltip.donation.matching": "Aquesta estimació es basa en les donacions fetes fins ara aquesta ronda de finançament quadràtic i no està considerant l'anàlisi de frau. La quantitat real de coincidència pot variar.",
+	"tooltip.donation.matching": "Aquesta estimació es basa en les donacions fetes fins ara aquesta ronda de finançament quadràtic i no està considerant l'anàlisi de frau. La quantitat real de coincidència pot variar."
 }

--- a/lang/t_es.json
+++ b/lang/t_es.json
@@ -111,7 +111,7 @@
 	"label.your_transactions_have_been_submitted": "Tus transacciones han sido enviadas",
 	"label.you_can_view_them_on_a_blockchain_explorer_here": "Puedes verlas en un explorador de blockchain aquí:",
 	"other_desc": " ",
-	"page.donate.matching_toast.bottom_valid": "Los fondos de igualación se enviarán al proyecto seleccionado después de que termine la ronda.",
+	"page.donate.matching_toast.bottom_valid": "Los fondos de emparejamiento se enviarán al proyecto seleccionado después de que termine la ronda. ¡Dona a más proyectos para recibir un mayor emparejamiento!",
 	"page.donate.matching_toast.upper_valid": "Igualación estimada",
 	"page.donate.passport_toast.description.eligible": "¡Tu donación es elegible para ser igualada! Después de la",
 	"page.donate.passport_toast.description.eligible_2": ", todas las donaciones serán revisadas para la protección contra fraudes y los fondos de igualación serán enviados a los proyectos. Mantente atento a las notificaciones :)",

--- a/src/components/views/donate/EstimatedMatchingToast.tsx
+++ b/src/components/views/donate/EstimatedMatchingToast.tsx
@@ -79,13 +79,30 @@ const EstimatedMatchingToast: React.FC<IEstimatedMatchingToast> = ({
 		<IconAlertTriangleFilled color={textColor} />
 	);
 
+	const formatWithCurrency = (
+		amount: number,
+		currency: string,
+		locale: string,
+	) => {
+		return (
+			formatDonation(amount, currency, locale, true) +
+			(currency ? '' : ' ' + allocatedTokenSymbol)
+		);
+	};
+
+	const getEstimatedMatchingRange = (esMatching: number) => {
+		if (esMatching >= 1) {
+			return `${formatWithCurrency((esMatching * 30) / 100, allocatedFundUSDPreferred ? '$' : '', locale)} - ${formatWithCurrency(esMatching, allocatedFundUSDPreferred ? '$' : '', locale)}`;
+		}
+		return formatWithCurrency(
+			esMatching,
+			allocatedFundUSDPreferred ? '$' : '',
+			locale,
+		);
+	};
+
 	const formattedDonation = isAboveMinValidUsdValue
-		? formatDonation(
-				esMatching,
-				allocatedFundUSDPreferred ? '$' : '',
-				locale,
-				true,
-			) + (allocatedFundUSDPreferred ? '' : ' ' + allocatedTokenSymbol)
+		? getEstimatedMatchingRange(esMatching)
 		: '---';
 
 	const bottomText = isAboveMinValidUsdValue

--- a/src/components/views/donate/EstimatedMatchingToast.tsx
+++ b/src/components/views/donate/EstimatedMatchingToast.tsx
@@ -86,7 +86,7 @@ const EstimatedMatchingToast: React.FC<IEstimatedMatchingToast> = ({
 	) => {
 		return (
 			formatDonation(amount, currency, locale, true) +
-			(currency ? '' : ' ' + allocatedTokenSymbol)
+			(currency ? '' : ` ${allocatedTokenSymbol}`)
 		);
 	};
 

--- a/src/components/views/project/projectActionCard/QFSection.tsx
+++ b/src/components/views/project/projectActionCard/QFSection.tsx
@@ -78,18 +78,33 @@ const QFSection: FC<IQFSectionProps> = ({ projectData }) => {
 	const isForeignOrg =
 		orgLabel !== ORGANIZATION.trace && orgLabel !== ORGANIZATION.giveth;
 
+	const formatWithCurrency = (
+		amount: number,
+		currency: string,
+		locale: string,
+	) => {
+		return (
+			formatDonation(amount, currency, locale, true) +
+			(currency ? '' : ' ' + allocatedTokenSymbol)
+		);
+	};
+
+	const getEstimatedMatchingRange = (esMatching: number) => {
+		if (esMatching >= 1) {
+			return `${formatWithCurrency((esMatching * 30) / 100, allocatedFundUSDPreferred ? '$' : '', locale)} - ${formatWithCurrency(esMatching, allocatedFundUSDPreferred ? '$' : '', locale)}`;
+		}
+		return formatWithCurrency(
+			esMatching,
+			allocatedFundUSDPreferred ? '$' : '',
+			locale,
+		);
+	};
+
 	const EstimatedMatchingSection = () =>
 		totalEstimatedMatching !== 0 ? (
 			<Flex $flexDirection='column' gap='4px'>
 				<EstimatedMatchingPrice>
-					{'+ ' +
-						formatDonation(
-							totalEstimatedMatching,
-							allocatedFundUSDPreferred ? '$' : '',
-							locale,
-							true,
-						)}{' '}
-					{allocatedFundUSDPreferred ? '' : allocatedTokenSymbol}
+					{getEstimatedMatchingRange(totalEstimatedMatching)}
 				</EstimatedMatchingPrice>
 				<Flex $alignItems='center' gap='4px'>
 					<LightCaption>
@@ -108,6 +123,29 @@ const QFSection: FC<IQFSectionProps> = ({ projectData }) => {
 				</Flex>
 			</Flex>
 		) : null;
+
+	const DonationMatch = ({ amount }: { amount: number }) => (
+		<FlexSameSize $justifyContent='space-between'>
+			<Subline>
+				{allocatedFundUSDPreferred && '$'}
+				{amount} {!allocatedFundUSDPreferred && allocatedTokenSymbol}
+			</Subline>
+			<IconArrowRight16 color={brandColors.cyan[500]} />
+			<EndAlignedSubline>
+				{getEstimatedMatchingRange(
+					calculateEstimatedMatchingWithDonationAmount(
+						amount,
+						projectDonationsSqrtRootSum,
+						allProjectsSum,
+						allocatedFundUSDPreferred
+							? allocatedFundUSD
+							: matchingPool,
+						activeStartedRound?.maximumReward,
+					),
+				)}
+			</EndAlignedSubline>
+		</FlexSameSize>
+	);
 
 	return (
 		<DonationSectionWrapper gap={isOnDonatePage ? '8px' : '24px'}>
@@ -225,93 +263,9 @@ const QFSection: FC<IQFSectionProps> = ({ projectData }) => {
 					</Flex>
 					<ContributionsContainer>
 						<Flex $flexDirection='column' gap='4px'>
-							<FlexSameSize $justifyContent='space-between'>
-								<Subline>
-									{allocatedFundUSDPreferred && '$'}1{' '}
-									{!allocatedFundUSDPreferred &&
-										allocatedTokenSymbol}
-								</Subline>
-								<IconArrowRight16
-									color={brandColors.cyan[500]}
-								/>
-								<EndAlignedSubline>
-									+{' '}
-									{formatDonation(
-										calculateEstimatedMatchingWithDonationAmount(
-											1,
-											projectDonationsSqrtRootSum,
-											allProjectsSum,
-											allocatedFundUSDPreferred
-												? allocatedFundUSD
-												: matchingPool,
-											activeStartedRound?.maximumReward,
-										),
-										allocatedFundUSDPreferred ? '$' : '',
-										locale,
-										true,
-									)}{' '}
-									{!allocatedFundUSDPreferred &&
-										allocatedTokenSymbol}
-								</EndAlignedSubline>
-							</FlexSameSize>
-							<FlexSameSize $justifyContent='space-between'>
-								<Subline>
-									{allocatedFundUSDPreferred && '$'}10{' '}
-									{!allocatedFundUSDPreferred &&
-										allocatedTokenSymbol}
-								</Subline>
-								<IconArrowRight16
-									color={brandColors.cyan[500]}
-								/>
-								<EndAlignedSubline>
-									+{' '}
-									{formatDonation(
-										calculateEstimatedMatchingWithDonationAmount(
-											10,
-											projectDonationsSqrtRootSum,
-											allProjectsSum,
-											allocatedFundUSDPreferred
-												? allocatedFundUSD
-												: matchingPool,
-											activeStartedRound?.maximumReward,
-										),
-										allocatedFundUSDPreferred ? '$' : '',
-										locale,
-										true,
-									)}{' '}
-									{!allocatedFundUSDPreferred &&
-										allocatedTokenSymbol}
-								</EndAlignedSubline>
-							</FlexSameSize>
-							<FlexSameSize $justifyContent='space-between'>
-								<Subline>
-									{allocatedFundUSDPreferred && '$'}100{' '}
-									{!allocatedFundUSDPreferred &&
-										allocatedTokenSymbol}
-								</Subline>
-								<IconArrowRight16
-									color={brandColors.cyan[500]}
-								/>
-								<EndAlignedSubline>
-									+{' '}
-									{formatDonation(
-										calculateEstimatedMatchingWithDonationAmount(
-											100,
-											projectDonationsSqrtRootSum,
-											allProjectsSum,
-											allocatedFundUSDPreferred
-												? allocatedFundUSD
-												: matchingPool,
-											activeStartedRound?.maximumReward,
-										),
-										allocatedFundUSDPreferred ? '$' : '',
-										locale,
-										true,
-									)}{' '}
-									{!allocatedFundUSDPreferred &&
-										allocatedTokenSymbol}
-								</EndAlignedSubline>
-							</FlexSameSize>
+							<DonationMatch amount={1} />
+							<DonationMatch amount={10} />
+							<DonationMatch amount={100} />
 							{/* <Flex $justifyContent='space-between'>
 							<LightSubline>Last updated: 3h ago</LightSubline>
 							<LightSubline>|</LightSubline>

--- a/src/components/views/project/projectActionCard/QFSection.tsx
+++ b/src/components/views/project/projectActionCard/QFSection.tsx
@@ -85,7 +85,7 @@ const QFSection: FC<IQFSectionProps> = ({ projectData }) => {
 	) => {
 		return (
 			formatDonation(amount, currency, locale, true) +
-			(currency ? '' : ' ' + allocatedTokenSymbol)
+			(currency ? '' : ` ${allocatedTokenSymbol}`)
 		);
 	};
 


### PR DESCRIPTION
Related to #4251 

Change Estimated matching to a range from 30% to 100% of the actual value

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced messages prompting users to donate to more projects to receive higher matching funds in various languages (Catalan, English, Spanish).

- **Enhancements**
  - Updated the `EstimatedMatchingToast` component to display an estimated matching range.
  - Refined the `QFSection` component with new functions for currency formatting and matching range calculation, and added a `DonationMatch` component.

- **Internationalization**
  - Enhanced translation files (Catalan, English, Spanish) to emphasize increased matching for additional donations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->