### PR TITLE
fix typo giv-earth round

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -67,7 +67,7 @@
 	"component.pro_guide.tips.social_media.item3": "Giveth might use your social media handles to contact you or tag you on posts to support your fundraising.",
 	"component.qf-section.tooltip": "This estimation is the matching funds that this project would get if the round ended now, disregarding fraud analysis.",
 	"component.qf-section.tooltip_polygon": "This estimate represents the matching funds this project would receive if the round closed now, ignoring the fraud analysis.",
-	"component.qf_middle_banner.desc": "With QF, the number of donors matters more than the amout donated. Donate to participating projects in the round and get your donations matched with the power of quadratic funding!",
+	"component.qf_middle_banner.desc": "With QF, the number of donors matters more than the amount donated. Donate to participating projects in the round and get your donations matched with the power of quadratic funding!",
 	"component.qf_middle_banner.title": "Quadratic Funding",
 	"component.regenstream_card.harvest_caption": "Use the Harvest button to claim liquid rewards from this RegenStream",
 	"component.reward_card.wrong_network": "{name} is available on {chains}. Please switch the network.",


### PR DESCRIPTION
#4323 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected a typo in the description of the `qf_middle_banner` component related to quadratic funding. Changed "amout" to "amount."

<!-- end of auto-generated comment: release notes by coderabbit.ai -->