### PR TITLE
Hotfix - Make sure chainId is not undefined when call create donation endpoint

### DIFF
--- a/src/hooks/useCreateEvmDonation.tsx
+++ b/src/hooks/useCreateEvmDonation.tsx
@@ -102,7 +102,7 @@ export const useCreateEvmDonation = () => {
 				transaction = await retryFetchEVMTransaction(txHash);
 				if (transaction) {
 					donationData = {
-						chainId: transaction.chainId!,
+						chainId: chainId || token.networkId,
 						txHash: transaction.hash,
 						amount: amount,
 						token,
@@ -131,7 +131,7 @@ export const useCreateEvmDonation = () => {
 				return id;
 			} catch (e: any) {
 				await postRequest('/api/donation-backup', true, {
-					chainId: transaction?.chainId!,
+					chainId: chainId || token.networkId,
 					txHash: transaction?.hash,
 					amount: amount,
 					token,

--- a/src/hooks/useCreateSolanaDonation.tsx
+++ b/src/hooks/useCreateSolanaDonation.tsx
@@ -90,7 +90,7 @@ export const useCreateSolanaDonation = () => {
 				return id;
 			} catch (e: any) {
 				await postRequest('/api/donation-backup', true, {
-					chainId: transaction?.chainId!,
+					chainId: transaction?.chainId || 0,
 					txHash: transaction?.hash,
 					amount: amount,
 					token,


### PR DESCRIPTION
related to https://github.com/Giveth/devops/issues/243

Here I explained why I made this PR
https://github.com/Giveth/devops/issues/243#issuecomment-2222535870

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability of the chain ID assignment in the donation processes to handle null or undefined values better. This ensures smoother transactions and fewer errors during donation creation.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->