### PR TITLE
Show 0 available balance when first time donate has been loaded

### DIFF
--- a/src/components/views/donate/OnTime/OneTimeDonationCard.tsx
+++ b/src/components/views/donate/OnTime/OneTimeDonationCard.tsx
@@ -360,10 +360,15 @@ const CryptoDonation: FC = () => {
 							id: 'label.available',
 						})}
 						:{' '}
-						{truncateToDecimalPlaces(
-							formatUnits(selectedTokenBalance, tokenDecimals),
-							tokenDecimals / 3,
-						)}
+						{selectedOneTimeToken
+							? truncateToDecimalPlaces(
+									formatUnits(
+										selectedTokenBalance,
+										tokenDecimals,
+									),
+									tokenDecimals / 3,
+								)
+							: 0.0}
 					</GLinkStyled>
 					<IconWrapper onClick={() => !isRefetching && refetch()}>
 						{isRefetching ? (


### PR DESCRIPTION
Resolve #3002

@divine-comedian fixed 0 balance in first load

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Enhancements**
  - Improved the display logic for token balances in the CryptoDonation component.
  - Token balance now only displays when a `selectedOneTimeToken` is present.
  - Dynamically formatted token balance for easier readability.
  - Added a conditional check to refetch data when necessary, providing more accurate and dynamic information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->