### PR TITLE
fix: add modal to QF Toast success page

### DIFF
--- a/src/apollo/gql/gqlQF.ts
+++ b/src/apollo/gql/gqlQF.ts
@@ -17,7 +17,7 @@ export const QF_ROUNDS_QUERY = `
 			allocatedFundUSD
 			allocatedFundUSDPreferred
 			allocatedTokenSymbol
-			minimumUserAnalysisScore
+			minMBDScore
 		}
 `;
 

--- a/src/apollo/types/types.ts
+++ b/src/apollo/types/types.ts
@@ -489,7 +489,7 @@ export interface IQFRound {
 	allocatedTokenSymbol: string;
 	allocatedTokenChainId: number;
 	minimumValidUsdValue?: number;
-	minimumUserAnalysisScore: number;
+	minMBDScore: number;
 }
 
 export interface IArchivedQFRound extends IQFRound {

--- a/src/components/views/donate/QFToast.tsx
+++ b/src/components/views/donate/QFToast.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react';
 import styled from 'styled-components';
 import {
 	Button,
@@ -10,13 +11,14 @@ import {
 } from '@giveth/ui-design-system';
 import { useIntl } from 'react-intl';
 import { EQFElegibilityState, usePassport } from '@/hooks/usePassport';
-import Routes from '@/lib/constants/Routes';
-import InternalLink from '@/components/InternalLink';
+import PassportModal from '@/components/modals/PassportModal';
 
 const QFToast = () => {
 	const { formatMessage, locale } = useIntl();
-	const { info } = usePassport();
-	const { qfEligibilityState, currentRound } = info;
+	const { info, refreshScore, handleSign, fetchUserMBDScore } = usePassport();
+	const { qfEligibilityState, passportState, passportScore, currentRound } =
+		info;
+	const [showModal, setShowModal] = useState<boolean>(false);
 
 	const isEligible = qfEligibilityState === EQFElegibilityState.ELIGIBLE;
 
@@ -66,28 +68,39 @@ const QFToast = () => {
 	}
 
 	return (
-		<Wrapper color={color}>
-			<Title $medium color={color}>
-				{title}
-			</Title>
-			<Description>{description}</Description>
-			<FlexCenter>
-				<InternalLink
-					href={isEligible ? Routes.QFProjects : Routes.QFElegibility}
-				>
-					<Button
-						label={formatMessage({
-							id: isEligible
-								? 'label.go_to_projects'
-								: 'qf_donor_eligibility.banner.link.check_eligibility',
-						})}
-						buttonType='primary'
-						size='small'
-						icon={<IconExternalLink16 />}
-					/>
-				</InternalLink>
-			</FlexCenter>
-		</Wrapper>
+		<>
+			<Wrapper color={color}>
+				<Title $medium color={color}>
+					{title}
+				</Title>
+				<Description>{description}</Description>
+				{!isEligible && (
+					<FlexCenter>
+						<Button
+							label={formatMessage({
+								id: 'qf_donor_eligibility.banner.link.check_eligibility',
+							})}
+							buttonType='primary'
+							size='small'
+							icon={<IconExternalLink16 />}
+							onAbort={() => setShowModal(true)}
+						/>
+					</FlexCenter>
+				)}
+			</Wrapper>
+			{showModal && (
+				<PassportModal
+					qfEligibilityState={qfEligibilityState}
+					passportState={passportState}
+					passportScore={passportScore}
+					currentRound={currentRound}
+					setShowModal={setShowModal}
+					refreshScore={refreshScore}
+					handleSign={handleSign}
+					fetchUserMBDScore={fetchUserMBDScore}
+				/>
+			)}
+		</>
 	);
 };
 

--- a/src/hooks/usePassport.ts
+++ b/src/hooks/usePassport.ts
@@ -152,9 +152,9 @@ export const usePassport = () => {
 				}
 
 				if (
-					activeQFRound.minimumUserAnalysisScore != null &&
+					activeQFRound.minMBDScore != null &&
 					refreshUserScores.activeQFMBDScore >=
-						activeQFRound.minimumUserAnalysisScore
+						activeQFRound.minMBDScore
 				) {
 					return setInfo({
 						qfEligibilityState: EQFElegibilityState.ELIGIBLE,
@@ -318,8 +318,7 @@ export const usePassport = () => {
 						user.activeQFMBDScore == null ||
 						(user.activeQFMBDScore != null &&
 							activeQFRound &&
-							user.activeQFMBDScore >=
-								activeQFRound.minimumUserAnalysisScore))
+							user.activeQFMBDScore >= activeQFRound.minMBDScore))
 				) {
 					console.log('******5', address, isUserFullFilled, user);
 					await updateState(user);


### PR DESCRIPTION
Related to #4247 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Updated eligibility and score checks in various components to use the new `minMBDScore` field.
  - Introduced a `fetchUserMBDScore` function for enhanced user score management.

- **Refactor**
  - Renamed `minimumUserAnalysisScore` to `minMBDScore` across multiple components for consistency and clarity.

- **UI/UX Improvements**
  - Enhanced the layout and logic in the eligibility status sections to provide a better user experience.
  - Adjusted rendering logic in the `QFToast` component to conditionally display modals based on user eligibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->