### PR TITLE
fix: 4453 update QF eligibility state when an error occurs

### DIFF
--- a/src/components/PassportBanner.tsx
+++ b/src/components/PassportBanner.tsx
@@ -111,7 +111,8 @@ export const PassportBannerData: IData = {
 };
 
 export const PassportBanner = () => {
-	const { info, fetchUserMBDScore, handleSign, refreshScore } = usePassport();
+	const { info, updateState, fetchUserMBDScore, handleSign, refreshScore } =
+		usePassport();
 	const { currentRound, passportState, passportScore, qfEligibilityState } =
 		info;
 
@@ -221,6 +222,7 @@ export const PassportBanner = () => {
 					passportScore={passportScore}
 					currentRound={currentRound}
 					setShowModal={setShowModal}
+					updateState={updateState}
 					refreshScore={refreshScore}
 					handleSign={handleSign}
 				/>

--- a/src/components/modals/PassportModal.tsx
+++ b/src/components/modals/PassportModal.tsx
@@ -360,11 +360,11 @@ const PassportModal: FC<PassportModalProps> = props => {
 };
 
 const StyledWrapper = styled.div`
-	padding: 16px;
 	display: flex;
+	margin-inline: auto;
+	padding: 16px;
 	flex-direction: column;
 	gap: 16px;
-	width: 600px;
 `;
 
 const PassportInfoBox = styled(P)`

--- a/src/components/modals/PassportModal.tsx
+++ b/src/components/modals/PassportModal.tsx
@@ -192,12 +192,10 @@ const PassportModal: FC<PassportModalProps> = props => {
 
 	const handleCloseModal = useCallback(() => {
 		closeModal();
-		console.log('closeModal');
 		if (
 			qfEligibilityState === EQFElegibilityState.ERROR ||
 			passportState === EPassportState.ERROR
 		) {
-			console.log('closeModal');
 			user && updateState?.(user);
 		}
 	}, [closeModal, qfEligibilityState, passportState, updateState, user]);

--- a/src/components/views/donate/QFToast.tsx
+++ b/src/components/views/donate/QFToast.tsx
@@ -15,7 +15,8 @@ import PassportModal from '@/components/modals/PassportModal';
 
 const QFToast = () => {
 	const { formatMessage, locale } = useIntl();
-	const { info, refreshScore, handleSign, fetchUserMBDScore } = usePassport();
+	const { info, updateState, refreshScore, handleSign, fetchUserMBDScore } =
+		usePassport();
 	const { qfEligibilityState, passportState, passportScore, currentRound } =
 		info;
 	const [showModal, setShowModal] = useState<boolean>(false);
@@ -95,6 +96,7 @@ const QFToast = () => {
 					passportScore={passportScore}
 					currentRound={currentRound}
 					setShowModal={setShowModal}
+					updateState={updateState}
 					refreshScore={refreshScore}
 					handleSign={handleSign}
 					fetchUserMBDScore={fetchUserMBDScore}

--- a/src/components/views/qfEligibility/Common.sc.tsx
+++ b/src/components/views/qfEligibility/Common.sc.tsx
@@ -18,7 +18,7 @@ export const QFEligibilityBG = styled(Flex)<{ $background: string }>`
 	flex-direction: column;
 	gap: 24px;
 	background-color: ${neutralColors.gray[100]};
-	width: 85%;
+	width: 98%;
 	max-width: 1076px;
 	position: relative;
 	overflow: hidden;
@@ -38,6 +38,10 @@ export const QFEligibilityBG = styled(Flex)<{ $background: string }>`
 	${mediaQueries.laptopS} {
 		min-height: 765px;
 	}
+
+	${mediaQueries.mobileL} {
+		width: 85%;
+	}
 `;
 
 export const QFEligibilityBGInner = styled(ContributeCardBox)`
@@ -46,8 +50,16 @@ export const QFEligibilityBGInner = styled(ContributeCardBox)`
 	flex-direction: column;
 	gap: 16px;
 	z-index: 1;
-	width: 50%;
+	width: 100%;
 	margin-block: auto;
+
+	${mediaQueries.tablet} {
+		width: 70%;
+	}
+
+	${mediaQueries.laptopS} {
+		width: 50%;
+	}
 `;
 
 export const EligibilityTop = styled(Flex)`

--- a/src/components/views/userProfile/common.sc.tsx
+++ b/src/components/views/userProfile/common.sc.tsx
@@ -22,8 +22,16 @@ export const PassportSection = styled.div`
 
 export const StyledNote = styled(P)`
 	display: flex;
-	align-items: center;
+	align-items: start;
 	gap: 8px;
+
+	:first-child {
+		margin-top: 3px;
+	}
+
+	:last-child {
+		min-width: 40px;
+	}
 `;
 
 export const QFMinScore = styled(P)`

--- a/src/hooks/usePassport.ts
+++ b/src/hooks/usePassport.ts
@@ -349,5 +349,5 @@ export const usePassport = () => {
 		activeQFRound,
 	]);
 
-	return { info, handleSign, refreshScore, fetchUserMBDScore };
+	return { info, updateState, handleSign, refreshScore, fetchUserMBDScore };
 };


### PR DESCRIPTION
Related to #4453 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Enhanced the PassportBanner and PassportModal components with a new state management function, improving interactivity.
	- Updated the QFToast component to utilize the new updateState function for better state management.
- **Bug Fixes**
	- Improved modal closure logic to ensure user state updates are managed correctly under certain conditions.
- **Style**
	- Adjusted the layout properties of QFEligibilityBG and QFEligibilityBGInner for improved responsiveness across devices.
	- Modified the styling of the StyledNote component to enhance its layout and visual structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->