### PR TITLE
post QA: change fetch-policy back to network-only

### DIFF
--- a/src/components/modals/PassportModal.tsx
+++ b/src/components/modals/PassportModal.tsx
@@ -186,6 +186,8 @@ const PassportModal: FC<PassportModalProps> = props => {
 							id: 'label.we_need_a_bit_more_info',
 						})
 					: formatMessage({ id: 'label.increase_your_score' });
+			case EQFElegibilityState.RECHECK_ELIGIBILITY:
+				return formatMessage({ id: 'label.increase_your_score' });
 			default:
 				return null;
 		}

--- a/src/services/passport.ts
+++ b/src/services/passport.ts
@@ -18,8 +18,7 @@ export const fetchPassportScore = async (account: string) => {
 			variables: {
 				address: account?.toLowerCase(),
 			},
-			// TODO - Change this to back to network-only once a test case is done by QA
-			fetchPolicy: 'cache-and-network',
+			fetchPolicy: 'network-only',
 		});
 		return data;
 	} catch (error) {


### PR DESCRIPTION
Related to https://github.com/Giveth/giveth-dapps-v2/issues/4453#issuecomment-2243159427

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced the Passport Modal to provide specific feedback when eligibility needs to be rechecked.
  
- **Bug Fixes**
	- Adjusted data fetching for passport scores to ensure the latest information is retrieved, improving data accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->