### PR TITLE
Fix: github validation regex expression

### DIFF
--- a/src/lib/constants/regex.ts
+++ b/src/lib/constants/regex.ts
@@ -19,7 +19,7 @@ export const regexList = {
 	discord:
 		/(?:https?:\/\/)?(?:www\.)?(?:discord\.gg|discord(?:app)?\.com\/invite)\/[\w-]+/,
 	phone: /^(\+\d{1,2}\s?)?\(?\d{3}\)?[\s.-]?\d{3}[\s.-]?\d{4}$/,
-	github: /^(http(s)?:\/\/)?(www\.)?github\.com\/[\w-]+\/?$/,
+	github: /^(https:\/\/)?(www\.)?github\.com\/[A-Za-z0-9_-]+(\/[A-Za-z0-9_-]+)?\/?$/,
 };
 
 export const validators = {


### PR DESCRIPTION
- #4484

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated URL validation for GitHub to support only HTTPS, enhancing security.
	- Improved regex pattern to accommodate a wider range of characters in repository names and optional path segments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->