### PR TITLE
fix: show accurate banner when round not started, ended, not active b…

### DIFF
--- a/src/components/views/userProfile/ProfileOverviewTab.tsx
+++ b/src/components/views/userProfile/ProfileOverviewTab.tsx
@@ -127,9 +127,10 @@ const ProfileOverviewTab: FC<IUserProfileView> = () => {
 	const givPower = getTotalGIVpower(subgraphValues, address);
 	const { title, subtitle, buttons } = section;
 
-	const activeStartedRound =
+	const activeStartedRoundNotEnded =
 		activeQFRound &&
-		new Date(activeQFRound.beginDate).getTime() < getNowUnixMS();
+		new Date(activeQFRound.beginDate).getTime() < getNowUnixMS() &&
+		new Date(activeQFRound.endDate).getTime() > getNowUnixMS();
 
 	useEffect(() => {
 		const setupSections = async () => {
@@ -216,7 +217,9 @@ const ProfileOverviewTab: FC<IUserProfileView> = () => {
 				) : (
 					<Row>
 						<Col lg={6}>
-							{activeStartedRound && <QFDonorEligibilityCard />}
+							{activeStartedRoundNotEnded && (
+								<QFDonorEligibilityCard />
+							)}
 						</Col>
 					</Row>
 				))

--- a/src/hooks/usePassport.ts
+++ b/src/hooks/usePassport.ts
@@ -330,22 +330,33 @@ export const usePassport = () => {
 	}, [address, isSafeEnv, setNotAvailableForGSafe, user]);
 
 	useEffect(() => {
-		console.log('******0', address, isUserFullFilled, user);
-		if (isSafeEnv) return setNotAvailableForGSafe();
-		if (!address) {
-			console.log('******1', address, isUserFullFilled, user);
-			return setInfo({
-				qfEligibilityState: EQFElegibilityState.NOT_CONNECTED,
-				passportState: EPassportState.NOT_CONNECTED,
-				passportScore: null,
-				activeQFMBDScore: null,
-				currentRound: null,
-			});
-		}
-		console.log('******2', address, isUserFullFilled, user);
-		if (!isUserFullFilled) return;
-		console.log('******3', address, isUserFullFilled, user);
 		const fetchData = async () => {
+			console.log('******0', address, isUserFullFilled, user);
+			const now = getNowUnixMS();
+
+			if (
+				isSafeEnv ||
+				isArchivedQF ||
+				!activeQFRound ||
+				now < new Date(activeQFRound.beginDate).getTime() ||
+				now > new Date(activeQFRound.endDate).getTime()
+			) {
+				return await updateState(user!);
+			}
+
+			if (!address) {
+				console.log('******1', address, isUserFullFilled, user);
+				return setInfo({
+					qfEligibilityState: EQFElegibilityState.NOT_CONNECTED,
+					passportState: EPassportState.NOT_CONNECTED,
+					passportScore: null,
+					activeQFMBDScore: null,
+					currentRound: null,
+				});
+			}
+			console.log('******2', address, isUserFullFilled, user);
+			if (!isUserFullFilled) return;
+			console.log('******3', address, isUserFullFilled, user);
 			if (!user || user.passportScore === null) {
 				console.log('******4', address, isUserFullFilled, user);
 				console.log('Passport score is null in our database');
@@ -397,10 +408,10 @@ export const usePassport = () => {
 		user,
 		address,
 		isSafeEnv,
+		isArchivedQF,
 		activeQFRound,
 		isUserFullFilled,
 		updateState,
-		setNotAvailableForGSafe,
 	]);
 
 	return {


### PR DESCRIPTION
…efore requesting user to connect

Related to #4247

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced display logic for the eligibility card in the user profile, ensuring it only shows when an active round is ongoing.
  - Improved eligibility checks in the passport functionality to account for additional factors, including the timing of the active round.

- **Bug Fixes**
  - Resolved issues with eligibility card visibility by refining the conditions for displaying the card based on the current round status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->