### PR TITLE
added recurring donation sum in project card of QF active round

### DIFF
--- a/src/apollo/gql/gqlProjects.ts
+++ b/src/apollo/gql/gqlProjects.ts
@@ -754,3 +754,32 @@ export const FETCH_RECURRING_DONATIONS_BY_PROJECTID = gql`
 		}
 	}
 `;
+export const FETCH_RECURRING_DONATIONS_BY_DATE = gql`
+	query ($projectId: Int!, $startDate: String, $endDate: String) {
+		recurringDonationsByDate(
+			projectId: $projectId
+			startDate: $startDate
+			endDate: $endDate
+		) {
+			recurringDonations {
+				id
+				txHash
+				networkId
+				flowRate
+				currency
+				anonymous
+				isArchived
+				status
+				totalUsdStreamed
+				donor {
+					id
+					walletAddress
+					firstName
+					email
+				}
+				createdAt
+			}
+			totalCount
+		}
+	}
+`;

--- a/src/components/project-card/ProjectCard.tsx
+++ b/src/components/project-card/ProjectCard.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import styled from 'styled-components';
 import {
 	P,
@@ -21,7 +21,7 @@ import { useRouter } from 'next/router';
 import { Shadow } from '@/components/styled-components/Shadow';
 import ProjectCardBadges from './ProjectCardBadgeButtons';
 import ProjectCardOrgBadge from './ProjectCardOrgBadge';
-import { IProject } from '@/apollo/types/types';
+import { IAdminUser, IProject } from '@/apollo/types/types';
 import { timeFromNow } from '@/lib/helpers';
 import ProjectCardImage from './ProjectCardImage';
 import { slugToProjectDonate, slugToProjectView } from '@/lib/routeCreators';
@@ -33,6 +33,8 @@ import { formatDonation } from '@/helpers/number';
 import { RoundNotStartedModal } from './RoundNotStartedModal';
 import { TooltipContent } from '@/components/modals/HarvestAll.sc';
 import { IconWithTooltip } from '@/components/IconWithToolTip';
+import { FETCH_RECURRING_DONATIONS_BY_DATE } from '@/apollo/gql/gqlProjects';
+import { client } from '@/apollo/apolloClient';
 
 const cardRadius = '12px';
 const imgHeight = '226px';
@@ -43,10 +45,24 @@ interface IProjectCard {
 	className?: string;
 	order?: number;
 }
-
+interface IRecurringDonation {
+	id: string;
+	txHash: string;
+	networkId: number;
+	currency: string;
+	anonymous: boolean;
+	status: string;
+	amountStreamed: number;
+	totalUsdStreamed: number;
+	flowRate: string;
+	donor: IAdminUser;
+	createdAt: string;
+	finished: boolean;
+}
 const ProjectCard = (props: IProjectCard) => {
 	const { project, className } = props;
 	const {
+		id,
 		title,
 		descriptionSummary,
 		image,
@@ -61,6 +77,7 @@ const ProjectCard = (props: IProjectCard) => {
 		qfRounds,
 		estimatedMatching,
 	} = project;
+	const [recurringDonationSumInQF, setRecurringDonationSumInQF] = useState(0);
 	const [isHover, setIsHover] = useState(false);
 	const [showHintModal, setShowHintModal] = useState(false);
 	const [destination, setDestination] = useState('');
@@ -95,6 +112,44 @@ const ProjectCard = (props: IProjectCard) => {
 			setShowHintModal(true);
 		}
 	};
+
+	const fetchProjectRecurringDonationsByDate = async () => {
+		const startDate = activeStartedRound?.beginDate;
+		const endDate = activeStartedRound?.endDate;
+		if (startDate && endDate) {
+			const { data: projectRecurringDonations } = await client.query({
+				query: FETCH_RECURRING_DONATIONS_BY_DATE,
+				variables: {
+					projectId: parseInt(id),
+					startDate,
+					endDate,
+				},
+			});
+			const { recurringDonationsByDate } = projectRecurringDonations;
+			return recurringDonationsByDate;
+		}
+	};
+	useEffect(() => {
+		const calculateTotalAmountStreamed = async () => {
+			if (activeStartedRound?.isActive) {
+				const donations = await fetchProjectRecurringDonationsByDate();
+				let totalAmountStreamed;
+				if (donations.totalCount != 0) {
+					console.log(id, donations.recurringDonations);
+					totalAmountStreamed = donations.recurringDonations.reduce(
+						(sum: number, donation: IRecurringDonation) => {
+							return sum + donation.totalUsdStreamed;
+						},
+						0,
+					);
+					setRecurringDonationSumInQF(totalAmountStreamed);
+				}
+				console.log(id, totalAmountStreamed);
+			}
+		};
+
+		calculateTotalAmountStreamed();
+	}, [props]);
 
 	return (
 		// </Link>
@@ -170,7 +225,8 @@ const ProjectCard = (props: IProjectCard) => {
 							<PriceText>
 								{formatDonation(
 									(activeStartedRound
-										? sumDonationValueUsdForActiveQfRound
+										? sumDonationValueUsdForActiveQfRound! +
+											recurringDonationSumInQF
 										: totalDonations) || 0,
 									'$',
 									locale,


### PR DESCRIPTION
Recurring donations made during the active QF round period are added to the amount raised in this round in the project card
Issue https://github.com/Giveth/giveth-dapps-v2/issues/4287


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a GraphQL query to fetch recurring donations by date, enhancing data retrieval capabilities.
	- Updated the ProjectCard component to calculate and display recurring donations, providing a comprehensive overview of project funding.

- **Bug Fixes**
	- Improved the rendering logic in the ProjectCard to correctly sum and display recurring donation totals.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->