### PR TITLE
chore: Change Project Dropdown givbacks feature

### DIFF
--- a/src/components/views/projects/sort/ProjectsSortSelect.tsx
+++ b/src/components/views/projects/sort/ProjectsSortSelect.tsx
@@ -7,7 +7,6 @@ import {
 	IconArrowBottom,
 	IconDonation16,
 	neutralColors,
-	IconFlash16,
 	IconRocketInSpace16,
 	IconIncrease16,
 	semanticColors,
@@ -15,6 +14,7 @@ import {
 	Flex,
 	IconPublish16,
 	IconEstimated16,
+	IconGIVBack16,
 } from '@giveth/ui-design-system';
 import Select, {
 	components,
@@ -59,7 +59,7 @@ const ProjectsSortSelect = () => {
 		{
 			label: formatMessage({ id: 'label.rank' }),
 			value: EProjectsSortBy.GIVPOWER,
-			icon: <IconFlash16 />,
+			icon: <IconGIVBack16 color={neutralColors.gray[900]} />,
 		},
 		{
 			label: formatMessage({ id: 'label.newest' }),


### PR DESCRIPTION
I have just replaced the IconFlash with IconGIVBack and added color props to it neutralColors.gray[900]

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **UI Enhancements**
	- Updated the icon for the GIVPOWER sorting option to improve visual consistency and aesthetics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->