### PR TITLE
Add zevm chain configs

### DIFF
--- a/src/components/cards/StakingCards/BaseStakingCard/StakingPoolInfoAndActions.tsx
+++ b/src/components/cards/StakingCards/BaseStakingCard/StakingPoolInfoAndActions.tsx
@@ -365,9 +365,13 @@ export const StakingPoolInfoAndActions: FC<IStakingPoolInfoAndActionsProps> = ({
 					<ClaimButton
 						disabled={availableStakedToken <= 0n}
 						onClick={() => setShowLockModal(true)}
-						label={formatMessage({
-							id: 'label.increase_rewards',
-						})}
+						label={
+							started
+								? formatMessage({
+										id: 'label.increase_rewards',
+									})
+								: 'Lock your GIV'
+						}
 						buttonType='primary'
 					/>
 				)}

--- a/src/components/cards/StakingCards/BaseStakingCard/StakingPoolInfoAndActions.tsx
+++ b/src/components/cards/StakingCards/BaseStakingCard/StakingPoolInfoAndActions.tsx
@@ -354,7 +354,7 @@ export const StakingPoolInfoAndActions: FC<IStakingPoolInfoAndActionsProps> = ({
 			)}
 			<HarvestButtonsWrapper>
 				<ClaimButton
-					disabled={exploited || earned === 0n}
+					disabled={exploited || earned === 0n || !started}
 					onClick={() => setShowHarvestModal(true)}
 					label={formatMessage({
 						id: 'label.harvest_rewards',

--- a/src/components/cards/StakingCards/BaseStakingCard/StakingPoolInfoAndActions.tsx
+++ b/src/components/cards/StakingCards/BaseStakingCard/StakingPoolInfoAndActions.tsx
@@ -505,6 +505,7 @@ export const StakingPoolInfoAndActions: FC<IStakingPoolInfoAndActionsProps> = ({
 					setShowModal={setShowLockModal}
 					poolStakingConfig={poolStakingConfig}
 					isGIVpower={isGIVpower}
+					started={started}
 				/>
 			)}
 			{showWhatIsGIVstreamModal && (

--- a/src/components/modals/StakeLock/Lock.tsx
+++ b/src/components/modals/StakeLock/Lock.tsx
@@ -43,6 +43,7 @@ import type { PoolStakingConfig } from '@/types/config';
 interface ILockModalProps extends IModal {
 	poolStakingConfig: PoolStakingConfig;
 	isGIVpower: boolean;
+	started: boolean;
 }
 
 export enum ELockState {
@@ -57,6 +58,7 @@ const LockModal: FC<ILockModalProps> = ({
 	poolStakingConfig,
 	isGIVpower,
 	setShowModal,
+	started,
 }) => {
 	const { formatMessage } = useIntl();
 	const isSafeEnv = useIsSafeEnvironment();
@@ -166,7 +168,11 @@ const LockModal: FC<ILockModalProps> = ({
 								</IconWithTooltip>
 							</Flex>
 							<LockSlider setRound={setRound} round={round} />
-							<LockInfo round={round} amount={amount} />
+							<LockInfo
+								round={round}
+								amount={amount}
+								farmIsNotStarted={!started}
+							/>
 							<StyledButton
 								buttonType='primary'
 								size='small'
@@ -200,7 +206,11 @@ const LockModal: FC<ILockModalProps> = ({
 								amount={amount}
 								onLocking
 							/>
-							<LockInfo round={round} amount={amount} />
+							<LockInfo
+								round={round}
+								amount={amount}
+								farmIsNotStarted={!started}
+							/>
 							<StyledButton
 								buttonType='primary'
 								label={formatMessage({

--- a/src/components/modals/StakeLock/LockInfo.tsx
+++ b/src/components/modals/StakeLock/LockInfo.tsx
@@ -23,9 +23,10 @@ import type { FC } from 'react';
 interface ILockInfo {
 	round: number;
 	amount: bigint;
+	farmIsNotStarted?: boolean;
 }
 
-const LockInfo: FC<ILockInfo> = ({ round, amount }) => {
+const LockInfo: FC<ILockInfo> = ({ round, amount, farmIsNotStarted }) => {
 	const { chain } = useAccount();
 	const chainId = chain?.id;
 	const { apr } =
@@ -71,7 +72,7 @@ const LockInfo: FC<ILockInfo> = ({ round, amount }) => {
 					</LockInfoRowHelp>
 				</LockInfoRowTitle>
 				<LockInfoRowValue>
-					{apr
+					{apr && !farmIsNotStarted
 						? `${formatEthHelper(
 								apr.effectiveAPR.multipliedBy(multipler),
 							)}%`

--- a/src/components/modals/StakeLock/LockInfo.tsx
+++ b/src/components/modals/StakeLock/LockInfo.tsx
@@ -72,11 +72,11 @@ const LockInfo: FC<ILockInfo> = ({ round, amount, farmIsNotStarted }) => {
 					</LockInfoRowHelp>
 				</LockInfoRowTitle>
 				<LockInfoRowValue>
-					{apr && !farmIsNotStarted
-						? `${formatEthHelper(
-								apr.effectiveAPR.multipliedBy(multipler),
-							)}%`
-						: ' ? '}
+					{farmIsNotStarted
+						? 'Coming Soon'
+						: !apr
+							? ' ? '
+							: `${formatEthHelper(apr.effectiveAPR.multipliedBy(multipler))}%`}
 					<LockInfoRowSpark>
 						<IconSpark size={16} />
 					</LockInfoRowSpark>
@@ -131,6 +131,7 @@ const MultiPlyHelp = styled.div`
 	top: -16px;
 	right: -20px;
 	cursor: pointer;
+
 	&:hover {
 		color: ${brandColors.giv[200]};
 	}
@@ -152,6 +153,7 @@ const LockInfoRowHelp = styled.div`
 	top: 1px;
 	right: -24px;
 	cursor: pointer;
+
 	&:hover {
 		color: ${brandColors.giv[200]};
 	}
@@ -163,6 +165,7 @@ const LockInfoRowSpark = styled.div`
 	left: -18px;
 	cursor: pointer;
 	color: ${brandColors.mustard[500]};
+
 	&:hover {
 		color: ${brandColors.mustard[400]};
 	}
@@ -170,6 +173,7 @@ const LockInfoRowSpark = styled.div`
 
 export const LockInfoTooltip = styled(Subline)`
 	color: ${neutralColors.gray[100]};
+
 	${mediaQueries.tablet} {
 		width: 160px;
 	}

--- a/src/components/modals/StakeLock/LockingBrief.tsx
+++ b/src/components/modals/StakeLock/LockingBrief.tsx
@@ -43,7 +43,7 @@ const LockingBrief: FC<ILockingBrief> = ({
 };
 
 export const BriefContainer = styled(Flex)`
-	color: ${brandColors.giv[300]};
+	color: ${brandColors.giv['000']};
 	flex-direction: column;
 	gap: 8px;
 `;

--- a/src/config/production.tsx
+++ b/src/config/production.tsx
@@ -34,6 +34,7 @@ import IconStellar from '@/components/Icons/Stellar';
 
 const GNOSIS_GIV_TOKEN_ADDRESS = '0x4f4F9b8D5B4d0Dc10506e5551B0513B61fD59e75';
 const OPTIMISM_GIV_TOKEN_ADDRESS = '0x528CDc92eAB044E1E39FE43B9514bfdAB4412B98';
+const ZKEVM_GIV_TOKEN_ADDRESS = '0xddAFB91475bBf6210a151FA911AC8fdA7dE46Ec2';
 
 const SEPT_8TH_2022 = 1662595200000;
 const MAINNET_NETWORK_NUMBER = 1; // Mainnet
@@ -579,6 +580,22 @@ const config: EnvConfig = {
 			// Keep it empty for automatic configuration
 		},
 		chainLogo: (logoSize?: number) => <IconZKEVM size={logoSize} />,
+		subgraphAddress: process.env.NEXT_PUBLIC_SUBGRAPH_ZKEVM,
+		GIV_TOKEN_ADDRESS: ZKEVM_GIV_TOKEN_ADDRESS,
+		GIV_BUY_LINK:
+			'https://velodrome.finance/swap?from=eth&to=0x528cdc92eab044e1e39fe43b9514bfdab4412b98',
+		TOKEN_DISTRO_ADDRESS: '0x4fB9B10ECDe1b048DBC79aBEAB3793edc93a0d54',
+		uniswapV2Subgraph: '',
+		GIVPOWER: {
+			network: ZKEVM_NETWORK_NUMBER,
+			LM_ADDRESS: '0xc790f82bf6f8709aa4a56dc11afad7af7c2a9867',
+			POOL_ADDRESS: ZKEVM_GIV_TOKEN_ADDRESS,
+			type: StakingType.GIV_UNIPOOL_LM,
+			platform: StakingPlatform.GIVETH,
+			title: 'GIV',
+			description: '100% GIV',
+			unit: 'GIV',
+		},
 	},
 	CLASSIC_CONFIG: {
 		...classic,

--- a/src/config/production.tsx
+++ b/src/config/production.tsx
@@ -595,6 +595,8 @@ const config: EnvConfig = {
 			title: 'GIV',
 			description: '100% GIV',
 			unit: 'GIV',
+			//Tuesday, September 3, 2024 6:00:00 PM
+			farmStartTimeMS: 1725386400000,
 		},
 	},
 	CLASSIC_CONFIG: {


### PR DESCRIPTION
related to #4433

**ZKEVM Mainnet config**: https://www.notion.so/giveth/641e512e33124a249177f67ba4762044?v=86ba47af2a9a4927a68cf0a8fcbe5c7d

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Added support for the ZKEVM network through new token addresses and configuration properties.
	- Enhanced token handling and flexibility in the application’s configuration.
	- Introduced new links and addresses for GIV token transactions and staking options.
	- Updated components to accept a new `started` prop for improved functionality in staking-related interactions.
	- Enhanced `LockInfo` component to conditionally display APR based on the farm's state.
	- Improved visual presentation of the `LockingBrief` component with updated color properties.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->