### PR TITLE
Removed coinbase and trust wallet providers

### DIFF
--- a/src/providers/solanaWalletProvider.tsx
+++ b/src/providers/solanaWalletProvider.tsx
@@ -30,8 +30,6 @@ export const SolanaCtx = createContext<any>(null);
 const wallets: BaseMessageSignerWalletAdapter<string>[] = [
 	new PhantomWalletAdapter(),
 	new SolflareWalletAdapter({ network: solanaAdapter }),
-	new CoinbaseWalletAdapter({ network: solanaAdapter }),
-	new TrustWalletAdapter() as BaseMessageSignerWalletAdapter<string>,
 ];
 
 if (!isProduction) {

--- a/src/providers/solanaWalletProvider.tsx
+++ b/src/providers/solanaWalletProvider.tsx
@@ -7,8 +7,6 @@ import {
 	UnsafeBurnerWalletAdapter,
 	PhantomWalletAdapter,
 	SolflareWalletAdapter,
-	CoinbaseWalletAdapter,
-	TrustWalletAdapter,
 } from '@solana/wallet-adapter-wallets';
 import { WalletModalProvider } from '@solana/wallet-adapter-react-ui';
 import { BaseMessageSignerWalletAdapter } from '@solana/wallet-adapter-base';


### PR DESCRIPTION
We are leaving support for Coinbase and Trust wallet Solana connectors

cc @divine-comedian 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
    - Streamlined wallet options by removing support for Coinbase and Trust Wallet adapters, now focusing on Phantom and Solflare wallets.
  
- **Impact**
    - Users will experience a simplified wallet selection process, potentially enhancing performance, but may have reduced choices for wallet compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->