### PR TITLE
fix/multisign modal notification

### DIFF
--- a/src/components/modals/SignWithWalletModal.tsx
+++ b/src/components/modals/SignWithWalletModal.tsx
@@ -243,7 +243,7 @@ export const SignWithWalletModal: FC<IProps> = ({
 						})}
 					</Description>
 				)}
-				{!multisigState.lastStep && (
+				{!multisigState.lastStep && isSafeEnv && (
 					<NoteDescription color='red'>
 						{formatMessage({
 							id: isGSafeConnector


### PR DESCRIPTION
- https://github.com/Giveth/giveth-dapps-v2/issues/4621#issuecomment-2318359928

Showing _red_ notification only if user are using safe multisign connection

With mutlisign:

![Screenshot 2024-08-30 at 11 07 14](https://github.com/user-attachments/assets/c3026c44-d155-4854-b01e-7c7cc5cc0842)

without multisign:

![Screenshot 2024-08-30 at 11 07 08](https://github.com/user-attachments/assets/63323f61-5eda-4963-94d1-bd3d2c0292d7)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced the `SignWithWalletModal` component to improve rendering logic based on specific environmental conditions, ensuring a better user experience.
  
- **Bug Fixes**
	- Adjusted control flow to prevent unnecessary UI elements from displaying when certain conditions are not met.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->