### PR TITLE
Add mainnet and sepolia to network selector

### DIFF
--- a/src/components/NetworkSelector.tsx
+++ b/src/components/NetworkSelector.tsx
@@ -36,6 +36,7 @@ export interface ISelected {
 const _options = [
 	{ network: config.GNOSIS_CONFIG, active: true },
 	{ network: config.OPTIMISM_CONFIG, active: true },
+	{ network: config.MAINNET_CONFIG, active: true },
 	{ network: config.ZKEVM_CONFIG, active: true },
 ];
 


### PR DESCRIPTION
related to  https://github.com/Giveth/giveth-dapps-v2/issues/4783#event-14403871038

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added Mainnet as an active network option in the Network Selector, expanding the selection alongside Gnosis, Optimism, and ZKEVM.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->