### PR TITLE
fix warpcast handle

### DIFF
--- a/src/helpers/url.tsx
+++ b/src/helpers/url.tsx
@@ -198,11 +198,18 @@ export const getSocialMediaHandle = (
 				/discord\.gg\/([^\/]+)/,
 			);
 		case 'farcaster':
-			// Assuming Farcaster uses a pattern like 'farcaster.xyz/username'
-			return extractUsernameFromPattern(
-				cleanedUrl,
-				/farcaster\.xyz\/([^\/]+)/,
-			);
+			const isWrapCast = cleanedUrl.includes('warpcast');
+			if (isWrapCast) {
+				return extractUsernameFromPattern(
+					cleanedUrl,
+					/warpcast\.com\/([^\/]+)/,
+				);
+			} else {
+				return extractUsernameFromPattern(
+					cleanedUrl,
+					/farcaster\.xyz\/([^\/]+)/,
+				);
+			}
 		case 'lens':
 			// Assuming Lens uses a pattern like 'lens.xyz/username'
 			return extractUsernameFromPattern(


### PR DESCRIPTION
- #3983

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved social media handle extraction for Farcaster URLs, now supporting both Warpcast and Farcaster.xyz domains.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->