### PR TITLE
Added missing clusterMatchingSyncAt to graphql

### DIFF
--- a/src/apollo/gql/gqlProjects.ts
+++ b/src/apollo/gql/gqlProjects.ts
@@ -198,6 +198,7 @@ export const FETCH_PROJECT_BY_SLUG_DONATION = gql`
 				allocatedFundUSD
 				minimumValidUsdValue
 				qfStrategy
+				clusterMatchingSyncAt
 			}
 			anchorContracts {
 				address

--- a/src/components/views/donate/OneTime/EstimatedMatchingToast.tsx
+++ b/src/components/views/donate/OneTime/EstimatedMatchingToast.tsx
@@ -46,7 +46,7 @@ const EstimatedMatchingToast: FC<IEstimatedMatchingToast> = ({
 		estimatedMatching || {};
 
 	const { activeStartedRound } = getActiveRound(qfRounds);
-	
+
 	const {
 		allocatedFundUSDPreferred,
 		allocatedFundUSD,

--- a/src/components/views/donate/OneTime/EstimatedMatchingToast.tsx
+++ b/src/components/views/donate/OneTime/EstimatedMatchingToast.tsx
@@ -46,6 +46,7 @@ const EstimatedMatchingToast: FC<IEstimatedMatchingToast> = ({
 		estimatedMatching || {};
 
 	const { activeStartedRound } = getActiveRound(qfRounds);
+	
 	const {
 		allocatedFundUSDPreferred,
 		allocatedFundUSD,


### PR DESCRIPTION
- https://github.com/Giveth/giveth-dapps-v2/issues/4274

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added `clusterMatchingSyncAt` field to project queries, providing additional synchronization information for cluster matching
  - Enhanced `EstimatedMatchingToast` component with new properties from active round data

- **Improvements**
  - Expanded data retrieval for project rounds with more detailed synchronization context

<!-- end of auto-generated comment: release notes by coderabbit.ai -->