### PR TITLE
Fix/QF round project enabled networks

### DIFF
--- a/src/components/views/donate/QFEligibleNetworks.tsx
+++ b/src/components/views/donate/QFEligibleNetworks.tsx
@@ -24,7 +24,8 @@ const QFEligibleNetworks = () => {
 	const [showModal, setShowModal] = useState(false);
 	const { isConnected } = useGeneralWallet();
 	const { formatMessage } = useIntl();
-	const { activeStartedRound } = useDonateData();
+	const { activeStartedRound, project } = useDonateData();
+	console.log('project', project);
 	const router = useRouter();
 	const isQRDonation = router.query.chain === ChainType.STELLAR.toLowerCase();
 	const eligibleNetworksWithoutStellar = activeStartedRound?.eligibleNetworks
@@ -42,24 +43,34 @@ const QFEligibleNetworks = () => {
 				{formatMessage({ id: 'label.eligible_networks_for_matching' })}
 			</Caption>
 			<IconsWrapper>
-				{activeStartedRound?.eligibleNetworks?.map(network => (
-					<IconWithTooltip
-						icon={
-							<TooltipIconWrapper>
-								{config.NETWORKS_CONFIG_WITH_ID[
-									network
-								]?.chainLogo(24)}
-							</TooltipIconWrapper>
-						}
-						direction='top'
-						align='top'
-						key={network}
-					>
-						<SublineBold>
-							{config.NETWORKS_CONFIG_WITH_ID[network]?.name}
-						</SublineBold>
-					</IconWithTooltip>
-				))}
+				{activeStartedRound?.eligibleNetworks?.map(network => {
+					// Check if project has an address for this network
+					const hasProjectAddress = project?.addresses?.some(
+						address =>
+							address.networkId === network &&
+							address.isRecipient,
+					);
+
+					// Only render if project has an address for this network
+					return hasProjectAddress ? (
+						<IconWithTooltip
+							icon={
+								<TooltipIconWrapper>
+									{config.NETWORKS_CONFIG_WITH_ID[
+										network
+									]?.chainLogo(24)}
+								</TooltipIconWrapper>
+							}
+							direction='top'
+							align='top'
+							key={network}
+						>
+							<SublineBold>
+								{config.NETWORKS_CONFIG_WITH_ID[network]?.name}
+							</SublineBold>
+						</IconWithTooltip>
+					) : null;
+				})}
 			</IconsWrapper>
 			{!isQRDonation && isConnected && (
 				<ButtonsWrapper>
@@ -99,15 +110,6 @@ const IconsWrapper = styled.div`
 	max-width: 100%; /* Ensure the content does not exceed the width of the parent */
 	max-height: 100%; /* Ensure the content does not exceed the height of the parent */
 	gap: 4px;
-	img {
-		filter: grayscale(100%);
-		opacity: 0.4;
-		transition: all 0.3s;
-		&:hover {
-			filter: grayscale(0);
-			opacity: 1;
-		}
-	}
 `;
 
 const ButtonsWrapper = styled.div`

--- a/src/components/views/project/projectActionCard/ProjectEligibleQFChains.tsx
+++ b/src/components/views/project/projectActionCard/ProjectEligibleQFChains.tsx
@@ -12,6 +12,7 @@ const ProjectEligibleQFChains = () => {
 	const { formatMessage } = useIntl();
 
 	const { activeStartedRound } = getActiveRound(projectData?.qfRounds);
+
 	return (
 		<Container>
 			<Wrapper>
@@ -21,24 +22,37 @@ const ProjectEligibleQFChains = () => {
 					})}
 				</Caption>
 				<IconsWrapper>
-					{activeStartedRound?.eligibleNetworks?.map(network => (
-						<IconWithTooltip
-							icon={
-								<TooltipIconWrapper>
-									{config.NETWORKS_CONFIG_WITH_ID[
-										network
-									]?.chainLogo(24)}
-								</TooltipIconWrapper>
-							}
-							direction='top'
-							align='top'
-							key={network}
-						>
-							<SublineBold>
-								{config.NETWORKS_CONFIG_WITH_ID[network]?.name}
-							</SublineBold>
-						</IconWithTooltip>
-					))}
+					{activeStartedRound?.eligibleNetworks?.map(network => {
+						// Check if project has an address for this network
+						const hasProjectAddress = projectData?.addresses?.some(
+							address =>
+								address.networkId === network &&
+								address.isRecipient,
+						);
+
+						// Only render if project has an address for this network
+						return hasProjectAddress ? (
+							<IconWithTooltip
+								icon={
+									<TooltipIconWrapper>
+										{config.NETWORKS_CONFIG_WITH_ID[
+											network
+										]?.chainLogo(24)}
+									</TooltipIconWrapper>
+								}
+								direction='top'
+								align='top'
+								key={network}
+							>
+								<SublineBold>
+									{
+										config.NETWORKS_CONFIG_WITH_ID[network]
+											?.name
+									}
+								</SublineBold>
+							</IconWithTooltip>
+						) : null;
+					})}
 				</IconsWrapper>
 			</Wrapper>
 		</Container>
@@ -60,17 +74,7 @@ const IconsWrapper = styled.div`
 	flex-wrap: wrap; /* Allow content to wrap to the next line */
 	max-width: 100%; /* Ensure the content does not exceed the width of the parent */
 	max-height: 100%; /* Ensure the content does not exceed the height of the parent */
-
 	gap: 8px;
-	img {
-		filter: grayscale(100%);
-		opacity: 0.4;
-		transition: all 0.3s;
-		&:hover {
-			filter: grayscale(0);
-			opacity: 1;
-		}
-	}
 `;
 
 const Wrapper = styled.div`


### PR DESCRIPTION
- https://github.com/Giveth/giveth-dapps-v2/issues/4999

@laurenluz I added here also eligible network icon in color, not more grey icon

![Screenshot 2025-02-18 at 10 52 11](https://github.com/user-attachments/assets/bd147c10-1a56-4f4f-b947-bc375269f501)

also now it only match project chains:

![Screenshot 2025-02-18 at 10 54 39](https://github.com/user-attachments/assets/c2ee77ca-7d1e-4b37-9c67-193464a9ec9b)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated the logic for displaying eligible network icons so that only networks with a valid project association are shown.
- **Style**
  - Adjusted the icon presentation by removing previous image effects, resulting in a cleaner, more streamlined display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->