### PR TITLE
Enable embedding Giveth profiles on Nounspace

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -153,22 +153,30 @@ const moduleExports = withBundleAnalyzer({
 		defaultLocale,
 	},
 	headers: async () => {
+		const safe      = 'https://app.safe.global';
+		const nounspace = ['https://nounspace.com', 'https://www.nounspace.com'];
+		const frameAncestors = ["'self'", safe, ...nounspace].join(' ');
+		// Declare additional consts and include them in frameAncestors to enable additional domains to embed Giveth pages in iframes.
 		return [
 			{
 				source: '/:path*',
 				locale: false,
 				headers: [
 					{
-						key: 'X-Frame-Options',
-						value: 'ALLOW-FROM https://app.safe.global',
-					},
-					{
 						key: 'Content-Security-Policy',
-						value: "frame-ancestors 'self' https://app.safe.global",
+						value: `frame-ancestors ${frameAncestors};`,
 					},
 					{
 						key: 'Access-Control-Allow-Origin',
-						value: 'https://app.safe.global',
+						value: '*',
+					},
+					{
+						key: 'Access-Control-Allow-Methods',
+					  	value: 'GET,HEAD,POST,OPTIONS',
+					},
+					{
+						key: 'Access-Control-Allow-Headers',
+						value: 'Origin,Accept,Content-Type,Authorization',
 					},
 					{
 						key: 'X-Content-Type-Options',
@@ -191,7 +199,7 @@ const moduleExports = withBundleAnalyzer({
 				headers: [
 					{
 						key: 'Access-Control-Allow-Origin',
-						value: 'https://app.safe.global',
+						value: '*',
 					},
 					{ key: 'Access-Control-Allow-Methods', value: 'GET' },
 					{


### PR DESCRIPTION
gm givers! would love to re-enable users on Nounspace to embed their Giveth profiles. this worked great at one point, and we've had a few users request this since.

Summary of changes made:

| Area | Original | Updated | Purpose |
|------|----------|---------|---------|
| **Framing header** | `X-Frame-Options: ALLOW-FROM …` plus a narrow CSP | **Removed** obsolete `X-Frame-Options` and replaced the CSP with<br>`frame-ancestors 'self' https://app.safe.global https://nounspace.com https://www.nounspace.com;` | Use the modern, standard-compliant `frame-ancestors` directive and whitelist both nounspace domains so any Giveth page can be embedded there while still working on Safe. 
 | **CORS (main block)** | `Access-Control-Allow-Origin: https://app.safe.global` | `Access-Control-Allow-Origin: *`<br>`Access-Control-Allow-Methods: GET,HEAD,POST,OPTIONS`<br>`Access-Control-Allow-Headers: Origin,Accept,Content-Type,Authorization` | A wildcard origin lets any site—including nounspace—make **read-only, non-credentialed** XHR/fetch requests. The extra method/header lines satisfy pre-flight checks.
 | **CORS (/manifest.json)** | Same single-origin header | Switched to the same wildcard approach as above | Consistency with the main block. 
 | **House-keeping** | — | • Added constants (`safe`, `nounspace`) and built `frameAncestors` string once for clarity.<br>• Added trailing semicolon in CSP for future directives. | Cleaner, DRYer config. |

**Net effect**
Embedding: Giveth pages can now render in an <iframe> on nounspace.com (or the www sub-domain) exactly as they do on giveth.io and Safe.

Security: Obsolete header removed; modern CSP used. Wildcard CORS is safe because the dapp doesn’t rely on cookies/credentials for public data requests.

Future domains: Add another URL to the list of consts and the frameAncestors const and redeploy—no further code changes required.

That’s it—the rest of the config (images, redirects, Sentry, etc.) remains untouched and fully functional.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Expanded support for embedding the app in iframes on multiple trusted domains.
  - Broadened CORS permissions, allowing requests from any origin and supporting additional HTTP methods and headers.

- **Chores**
  - Updated security and CORS headers for improved compatibility and flexibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->