### PR TITLE
Added network number in locker slider parameters

### DIFF
--- a/src/components/modals/StakeLock/Lock.tsx
+++ b/src/components/modals/StakeLock/Lock.tsx
@@ -167,7 +167,7 @@ const LockModal: FC<ILockModalProps> = ({
 									</LockInfoTooltip>
 								</IconWithTooltip>
 							</Flex>
-							<LockSlider setRound={setRound} round={round} />
+							<LockSlider setRound={setRound} round={round} chainNumber={poolNetwork}/>
 							<LockInfo
 								round={round}
 								amount={amount}

--- a/src/components/modals/StakeLock/Lock.tsx
+++ b/src/components/modals/StakeLock/Lock.tsx
@@ -167,7 +167,11 @@ const LockModal: FC<ILockModalProps> = ({
 									</LockInfoTooltip>
 								</IconWithTooltip>
 							</Flex>
-							<LockSlider setRound={setRound} round={round} chainNumber={poolNetwork}/>
+							<LockSlider
+								setRound={setRound}
+								round={round}
+								chainNumber={poolNetwork}
+							/>
 							<LockInfo
 								round={round}
 								amount={amount}

--- a/src/components/modals/StakeLock/LockSlider.tsx
+++ b/src/components/modals/StakeLock/LockSlider.tsx
@@ -22,13 +22,14 @@ const maxRound = 26;
 interface ILockSlider {
 	round: number;
 	setRound: Dispatch<SetStateAction<number>>;
+	chainNumber: number
 }
 
-const LockSlider: FC<ILockSlider> = ({ round, setRound }) => {
+const LockSlider: FC<ILockSlider> = ({ round, setRound, chainNumber }) => {
 	const { formatMessage, locale } = useIntl();
 	const [isChanged, setIsChanged] = useState(false);
-	const gnosisValues = useSubgraphInfo(config.GNOSIS_NETWORK_NUMBER);
-	const givpowerInfo = gnosisValues.data?.givpowerInfo as IGIVpower;
+	const subgraphInfo = useSubgraphInfo(chainNumber);
+	const givpowerInfo = subgraphInfo.data?.givpowerInfo as IGIVpower;
 	const unlockDate = new Date(getUnlockDate(givpowerInfo, round));
 	return (
 		<>

--- a/src/components/modals/StakeLock/LockSlider.tsx
+++ b/src/components/modals/StakeLock/LockSlider.tsx
@@ -14,7 +14,6 @@ import { Dispatch, FC, SetStateAction, useState } from 'react';
 import { useIntl } from 'react-intl';
 import { smallFormatDate } from '@/lib/helpers';
 import { getUnlockDate } from '@/helpers/givpower';
-import config from '@/configuration';
 import { useSubgraphInfo } from '@/hooks/useSubgraphInfo';
 import type { IGIVpower } from '@/types/subgraph';
 
@@ -22,7 +21,7 @@ const maxRound = 26;
 interface ILockSlider {
 	round: number;
 	setRound: Dispatch<SetStateAction<number>>;
-	chainNumber: number
+	chainNumber: number;
 }
 
 const LockSlider: FC<ILockSlider> = ({ round, setRound, chainNumber }) => {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced the lock slider in the staking modal to support multiple networks, adapting its behavior based on the selected pool's network.

- **Bug Fixes**
  - Improved accuracy of network-specific information displayed in the lock slider.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->