### PR TITLE
fix: Streamline donor user flow for Stellar-only QF rounds

### DIFF
--- a/lang/ct.json
+++ b/lang/ct.json
@@ -776,6 +776,7 @@
 	"label.please_connect_your_wallet_to_match": "Connecteu la vostra cartera per igualar la vostra donació a QF",
 	"label.please_connect_your_wallet_to_win_givbacks": "Connecta la teva cartera per guanyar GIVbacks.",
 	"label.please_connect_your_wallet_to_win_givbacks_and_match": "Connecta la teva cartera per guanyar GIVbacks i igualar la teva donació en QF.",
+	"label.sign_into_giveth_for_a_chance_to_win_givbacks": "Inicia sessió en Giveth per guanyar GIVbacks.",
 	"label.please_contact_support_team": "Si us plau, contacteu l'equip de suport.",
 	"label.please_do_not_enter_exchange_deposit": "Si us plau, NO introduïu una adreça de dipòsit d'intercanvi, o els vostres fons podrien perdre's! Utilitzeu un compte que controleu en aquesta xarxa. Recomanem utilitzar Metamask.",
 	"label.please_do_not_enter_exchange_deposit_solana": "Si us plau, NO introdueixis una adreça de dipòsit d'un exchange, o podries perdre els teus fons! Utilitza un compte que controlis en aquesta xarxa. Et recomanem utilitzar Metamask. A més, Giveth NO dona suport a l'enviament de donacions a MULTISIGS a la xarxa Solana.",

--- a/lang/en.json
+++ b/lang/en.json
@@ -777,6 +777,7 @@
 	"label.please_connect_your_wallet_to_match": "Connect your wallet to match your donation in QF",
 	"label.please_connect_your_wallet_to_win_givbacks": "Connect your wallet to win GIVbacks.",
 	"label.please_connect_your_wallet_to_win_givbacks_and_match": "Connect your wallet to win GIVbacks and match your donation in QF.",
+	"label.sign_into_giveth_for_a_chance_to_win_givbacks": "Sign into Giveth for a chance to win GIVbacks.",
 	"label.please_contact_support_team": "Please contact support team.",
 	"label.please_do_not_enter_exchange_deposit": "Please DO NOT enter an exchange deposit address, or your funds maybe lost! Use an account you control on this network. We recommend using Metamask.",
 	"label.please_do_not_enter_exchange_deposit_solana": "Please DO NOT enter an exchange deposit address, or your funds maybe lost! Use an account you control on this network. We recommend using Metamask. Additionally Giveth does NOT support sending donations to MULTISIGS on the Solana network.",

--- a/lang/es.json
+++ b/lang/es.json
@@ -776,6 +776,7 @@
 	"label.please_connect_your_wallet_to_match": "Conecta tu billetera para igualar tu donación en QF",
 	"label.please_connect_your_wallet_to_win_givbacks": "Conecta tu billetera para ganar GIVbacks.",
 	"label.please_connect_your_wallet_to_win_givbacks_and_match": "Conecta tu billetera para ganar GIVbacks e igualar tu donación en QF.",
+	"label.sign_into_giveth_for_a_chance_to_win_givbacks": "Inicia sesión en Giveth para ganar GIVbacks.",
 	"label.please_contact_support_team": "Por favor contacta al equipo de soporte.",
 	"label.please_do_not_enter_exchange_deposit": "¡Por favor, NO introduzcas una dirección de depósito de intercambio, o podrías perder tus fondos! Usa una cuenta que controles en esta red. Recomendamos usar Metamask.",
 	"label.please_do_not_enter_exchange_deposit_solana": "¡Por favor, NO ingreses una dirección de depósito de un exchange, ¡o podrías perder tus fondos! Usa una cuenta que controles en esta red. Recomendamos usar Metamask. Además, Giveth NO admite el envío de donaciones a MULTISIGS en la red de Solana.",

--- a/src/apollo/gql/gqlProjects.ts
+++ b/src/apollo/gql/gqlProjects.ts
@@ -20,6 +20,7 @@ export const PROJECT_CORE_FIELDS = gql`
 			allocatedTokenSymbol
 			allocatedFundUSDPreferred
 			allocatedFundUSD
+			eligibleNetworks
 		}
 	}
 `;

--- a/src/apollo/gql/gqlQF.ts
+++ b/src/apollo/gql/gqlQF.ts
@@ -19,6 +19,7 @@ export const QF_ROUNDS_QUERY = `
 			allocatedTokenSymbol
 			minMBDScore
 			minimumValidUsdValue
+			eligibleNetworks
 		}
 `;
 

--- a/src/components/project-card/ProjectCard.tsx
+++ b/src/components/project-card/ProjectCard.tsx
@@ -22,7 +22,11 @@ import ProjectCardOrgBadge from './ProjectCardOrgBadge';
 import { IAdminUser, IProject } from '@/apollo/types/types';
 import { timeFromNow } from '@/lib/helpers';
 import ProjectCardImage from './ProjectCardImage';
-import { slugToProjectDonate, slugToProjectView } from '@/lib/routeCreators';
+import {
+	slugToProjectDonate,
+	slugToProjectDonateStellar,
+	slugToProjectView,
+} from '@/lib/routeCreators';
 import { ORGANIZATION } from '@/lib/constants/organizations';
 import { mediaQueries } from '@/lib/constants/constants';
 import { ProjectCardUserName } from './ProjectCardUserName';
@@ -32,7 +36,7 @@ import { FETCH_RECURRING_DONATIONS_BY_DATE } from '@/apollo/gql/gqlProjects';
 import { client } from '@/apollo/apolloClient';
 import { ProjectCardTotalRaised } from './ProjectCardTotalRaised';
 import { ProjectCardTotalRaisedQF } from './ProjectCardTotalRaisedQF';
-
+import config from '@/configuration';
 const cardRadius = '12px';
 const imgHeight = '226px';
 const SIDE_PADDING = '26px';
@@ -84,15 +88,22 @@ const ProjectCard = (props: IProjectCard) => {
 	const isForeignOrg =
 		orgLabel !== ORGANIZATION.trace && orgLabel !== ORGANIZATION.giveth;
 	const name = adminUser?.name;
-	const { formatMessage, formatRelativeTime, locale } = useIntl();
+	const { formatMessage, formatRelativeTime } = useIntl();
 	const router = useRouter();
 
 	const { activeStartedRound, activeQFRound } = getActiveRound(qfRounds);
 	const hasFooter = activeStartedRound || verified || isGivbackEligible;
 	const showVerifiedBadge = verified || isGivbackEligible;
 
+	const isStellarOnlyRound =
+		activeStartedRound?.eligibleNetworks?.length === 1 &&
+		activeStartedRound?.eligibleNetworks[0] ===
+			config.STELLAR_NETWORK_NUMBER;
+
 	const projectLink = slugToProjectView(slug);
-	const donateLink = slugToProjectDonate(slug);
+	const donateLink = isStellarOnlyRound
+		? slugToProjectDonateStellar(slug)
+		: slugToProjectDonate(slug);
 
 	// Show hint modal if the user clicks on the card and the round is not started
 	const handleClick = (e: any) => {

--- a/src/components/views/donate/DonateIndex.tsx
+++ b/src/components/views/donate/DonateIndex.tsx
@@ -265,7 +265,10 @@ const DonateIndex: FC = () => {
 				isSuccessDonation={Object.keys(successDonation).length > 0}
 			/>
 			<DonateSuccessContainer>
-				<SuccessView isStellar={isQRDonation} />
+				<SuccessView
+					isStellar={isQRDonation}
+					isStellarInQF={isStellarIncludedInQF}
+				/>
 			</DonateSuccessContainer>
 		</>
 	) : (

--- a/src/components/views/donate/DonateIndex.tsx
+++ b/src/components/views/donate/DonateIndex.tsx
@@ -95,6 +95,11 @@ const DonateIndex: FC = () => {
 			config.STELLAR_NETWORK_NUMBER,
 		);
 
+	const isStellarOnlyQF =
+		isQRDonation &&
+		activeStartedRound?.eligibleNetworks?.length === 1 &&
+		isStellarIncludedInQF;
+
 	useEffect(() => {
 		dispatch(setShowHeader(false));
 		return () => {
@@ -313,10 +318,7 @@ const DonateIndex: FC = () => {
 					{!isSafeEnv &&
 						hasActiveQFRound &&
 						!isOnSolana &&
-						(!isQRDonation ||
-							(isQRDonation && isStellarIncludedInQF)) && (
-							<PassportBanner />
-						)}
+						!isStellarOnlyQF && <PassportBanner />}
 					<Row>
 						<Col xs={12} lg={6}>
 							<DonationCard

--- a/src/components/views/donate/OneTime/SelectTokenModal/QRCodeDonation/QRDonationCard.tsx
+++ b/src/components/views/donate/OneTime/SelectTokenModal/QRCodeDonation/QRDonationCard.tsx
@@ -108,15 +108,20 @@ export const QRDonationCard: FC<QRDonationCardProps> = ({
 		address => address.chainType === ChainType.STELLAR,
 	);
 
+	const isStellar = router.query.chain === ChainType.STELLAR.toLowerCase();
+
 	const isOnEligibleNetworks = activeStartedRound?.eligibleNetworks?.includes(
 		config.STELLAR_NETWORK_NUMBER,
 	);
 	const isProjectGivbacksEligible = !!verified;
 	const isInQF = !!isOnEligibleNetworks;
 	const showConnectWallet = isProjectGivbacksEligible || isInQF;
+
 	const textToDisplayOnConnect =
 		isProjectGivbacksEligible && isInQF
-			? 'label.please_connect_your_wallet_to_win_givbacks_and_match'
+			? isStellar
+				? 'label.sign_into_giveth_for_a_chance_to_win_givbacks'
+				: 'label.please_connect_your_wallet_to_win_givbacks_and_match'
 			: isProjectGivbacksEligible
 				? 'label.please_connect_your_wallet_to_win_givbacks'
 				: 'label.please_connect_your_wallet_to_match';
@@ -323,14 +328,17 @@ export const QRDonationCard: FC<QRDonationCardProps> = ({
 					})}
 				/>
 			)}
-			{!showQRCode && !isConnected && showConnectWallet && (
-				<ConnectWallet>
-					<IconWalletOutline24 color={neutralColors.gray[700]} />
-					{formatMessage({
-						id: textToDisplayOnConnect,
-					})}
-				</ConnectWallet>
-			)}
+			{!showQRCode &&
+				!isConnected &&
+				showConnectWallet &&
+				(isStellar || !isOnEligibleNetworks) && (
+					<ConnectWallet>
+						<IconWalletOutline24 color={neutralColors.gray[700]} />
+						{formatMessage({
+							id: textToDisplayOnConnect,
+						})}
+					</ConnectWallet>
+				)}
 			{!showQRCode && (
 				<EligibilityBadges
 					amount={amount}

--- a/src/components/views/donate/QFEligibleNetworks.tsx
+++ b/src/components/views/donate/QFEligibleNetworks.tsx
@@ -35,6 +35,11 @@ const QFEligibleNetworks = () => {
 				? ChainType.EVM
 				: ChainType.SOLANA,
 		}));
+	const isStellarOnlyRound =
+		activeStartedRound?.eligibleNetworks?.length === 1 &&
+		activeStartedRound?.eligibleNetworks[0] ===
+			config.STELLAR_NETWORK_NUMBER;
+
 	if (!activeStartedRound) return null;
 	return (
 		<Wrapper>
@@ -71,19 +76,23 @@ const QFEligibleNetworks = () => {
 					) : null;
 				})}
 			</IconsWrapper>
-			{!isQRDonation && isConnected && (
+			{!isQRDonation && isConnected && !isStellarOnlyRound && (
 				<ButtonsWrapper>
 					<OutlineButton
 						onClick={() => setShowModal(true)}
 						size='medium'
 						icon={<IconNetwork24 />}
-						label={formatMessage({ id: 'label.switch_network' })}
+						label={formatMessage({
+							id: 'label.switch_network',
+						})}
 					/>
 					<ExternalLink href={links.ACROSS_BRIDGE}>
 						<OutlineButton
 							size='medium'
 							icon={<IconExternalLink24 />}
-							label={formatMessage({ id: 'label.bridge_tokens' })}
+							label={formatMessage({
+								id: 'label.bridge_tokens',
+							})}
 						/>
 					</ExternalLink>
 				</ButtonsWrapper>

--- a/src/components/views/donate/QFToast.tsx
+++ b/src/components/views/donate/QFToast.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { FC, useState } from 'react';
 import styled from 'styled-components';
 import {
 	Button,
@@ -14,7 +14,12 @@ import { useRouter } from 'next/router';
 import { EQFElegibilityState, usePassport } from '@/hooks/usePassport';
 import PassportModal from '@/components/modals/PassportModal';
 
-const QFToast = () => {
+interface IQFToast {
+	isStellarInQF?: boolean;
+	isStellar?: boolean;
+}
+
+const QFToast: FC<IQFToast> = ({ isStellarInQF, isStellar }) => {
 	const { formatMessage, locale } = useIntl();
 	const { info, updateState, refreshScore, handleSign, fetchUserMBDScore } =
 		usePassport();
@@ -23,7 +28,9 @@ const QFToast = () => {
 	const router = useRouter();
 	const [showModal, setShowModal] = useState<boolean>(false);
 
-	const isEligible = qfEligibilityState === EQFElegibilityState.ELIGIBLE;
+	const isEligible =
+		qfEligibilityState === EQFElegibilityState.ELIGIBLE ||
+		(isStellarInQF && isStellar);
 
 	const color = isEligible
 		? semanticColors.jade['500']

--- a/src/components/views/donate/SuccessView.tsx
+++ b/src/components/views/donate/SuccessView.tsx
@@ -39,8 +39,9 @@ import ImprovementBanner from './ImprovementBanner';
 
 interface ISuccessView {
 	isStellar?: boolean;
+	isStellarInQF?: boolean;
 }
-export const SuccessView: FC<ISuccessView> = ({ isStellar }) => {
+export const SuccessView: FC<ISuccessView> = ({ isStellar, isStellarInQF }) => {
 	const { formatMessage } = useIntl();
 	const { successDonation, hasActiveQFRound, project } = useDonateData();
 	const {
@@ -100,12 +101,13 @@ export const SuccessView: FC<ISuccessView> = ({ isStellar }) => {
 		!isSafeEnv &&
 		hasActiveQFRound &&
 		isOnEligibleNetworks &&
-		passportState !== EPassportState.CONNECTING &&
-		passportState !== EPassportState.LOADING_SCORE &&
-		qfEligibilityState !== EQFElegibilityState.LOADING &&
-		qfEligibilityState !== EQFElegibilityState.PROCESSING &&
-		qfEligibilityState !== EQFElegibilityState.NOT_CONNECTED &&
-		qfEligibilityState !== EQFElegibilityState.ERROR;
+		((isStellarInQF && isStellar) ||
+			(passportState !== EPassportState.CONNECTING &&
+				passportState !== EPassportState.LOADING_SCORE &&
+				qfEligibilityState !== EQFElegibilityState.LOADING &&
+				qfEligibilityState !== EQFElegibilityState.PROCESSING &&
+				qfEligibilityState !== EQFElegibilityState.NOT_CONNECTED &&
+				qfEligibilityState !== EQFElegibilityState.ERROR));
 
 	return (
 		<Wrapper>
@@ -158,7 +160,12 @@ export const SuccessView: FC<ISuccessView> = ({ isStellar }) => {
 								<br />
 							</>
 						)}
-						{showQFToast && <QFToast />}
+						{showQFToast && (
+							<QFToast
+								isStellar={isStellar}
+								isStellarInQF={isStellarInQF}
+							/>
+						)}
 						{isRecurring && <ManageRecurringDonation />}
 						<SocialBoxWrapper>
 							<SocialBox

--- a/src/components/views/donate/common/EligibilityBadges.tsx
+++ b/src/components/views/donate/common/EligibilityBadges.tsx
@@ -48,6 +48,7 @@ const EligibilityBadges: FC<IEligibilityBadges> = props => {
 
 	const isOnQFEligibleNetworks =
 		activeStartedRound?.eligibleNetworks?.includes(networkId || 0);
+
 	const decimals = isStellar ? 18 : token?.decimals || 18;
 
 	const donationUsdValue =
@@ -75,7 +76,7 @@ const EligibilityBadges: FC<IEligibilityBadges> = props => {
 				? 'page.donate.unlocks_matching_funds'
 				: null; // Prevents invalid id values
 
-	return isConnected ? (
+	return isConnected || (isStellar && !isOnQFEligibleNetworks) ? (
 		<EligibilityBadgeWrapper style={style}>
 			{/* Prevents QF Badge from rendering when !isOnQFEligibleNetworks && !activeStartedRound */}
 			{!(isOnQFEligibleNetworks || activeStartedRound) ? null : (

--- a/src/components/views/project/ProjectIndex.tsx
+++ b/src/components/views/project/ProjectIndex.tsx
@@ -50,6 +50,8 @@ import { ChainType } from '@/types/config';
 import { useAppSelector } from '@/features/hooks';
 import { EndaomentProjectsInfo } from '@/components/views/project/EndaomentProjectsInfo';
 import VerifyEmailBanner from '../userProfile/VerifyEmailBanner';
+import config from '@/configuration';
+import { getActiveRound } from '@/helpers/qf';
 
 const ProjectDonations = dynamic(
 	() => import('./projectDonations/ProjectDonations.index'),
@@ -90,6 +92,7 @@ const ProjectIndex: FC<IProjectBySlug> = () => {
 	} = useProjectContext();
 
 	const { isOnSolana } = useGeneralWallet();
+	const { activeStartedRound } = getActiveRound(projectData?.qfRounds);
 
 	const router = useRouter();
 	const slug = router.query.projectIdSlug as string;
@@ -109,6 +112,12 @@ const ProjectIndex: FC<IProjectBySlug> = () => {
 	};
 
 	const isEmailVerifiedStatus = isAdmin ? isAdminEmailVerified : true;
+	const isStellarOnlyQF =
+		hasActiveQFRound &&
+		activeStartedRound?.eligibleNetworks?.length === 1 &&
+		activeStartedRound?.eligibleNetworks?.includes(
+			config.STELLAR_NETWORK_NUMBER,
+		);
 
 	useEffect(() => {
 		if (!isSSRMode) {
@@ -158,9 +167,10 @@ const ProjectIndex: FC<IProjectBySlug> = () => {
 	return (
 		<Wrapper>
 			{!isAdminEmailVerified && isAdmin && <VerifyEmailBanner />}
-			{hasActiveQFRound && !isOnSolana && isAdminEmailVerified && (
-				<PassportBanner />
-			)}
+			{hasActiveQFRound &&
+				!isOnSolana &&
+				!isStellarOnlyQF &&
+				isAdminEmailVerified && <PassportBanner />}
 			<Head>
 				<title>{title && `${title} |`} Giveth</title>
 				<ProjectMeta project={projectData} />

--- a/src/components/views/project/projectActionCard/ProjectPublicActions.tsx
+++ b/src/components/views/project/projectActionCard/ProjectPublicActions.tsx
@@ -27,9 +27,14 @@ import { useModalCallback } from '@/hooks/useModalCallback';
 import { bookmarkProject, unBookmarkProject } from '@/lib/reaction';
 import { FETCH_PROJECT_REACTION_BY_ID } from '@/apollo/gql/gqlProjects';
 import { client } from '@/apollo/apolloClient';
-import { slugToProjectDonate } from '@/lib/routeCreators';
+import {
+	slugToProjectDonate,
+	slugToProjectDonateStellar,
+} from '@/lib/routeCreators';
 import { useAlreadyDonatedToProject } from '@/hooks/useAlreadyDonatedToProject';
 import { BadgeButton } from '@/components/project-card/ProjectCardBadgeButtons';
+import config from '@/configuration';
+import { getActiveRound } from '@/helpers/qf';
 
 export const ProjectPublicActions = () => {
 	const [showModal, setShowShareModal] = useState<boolean>(false);
@@ -46,7 +51,13 @@ export const ProjectPublicActions = () => {
 	} = useAppSelector(state => state.user);
 	const { formatMessage } = useIntl();
 	const { open: openConnectModal } = useWeb3Modal();
+	const { activeStartedRound } = getActiveRound(projectData?.qfRounds);
 	const alreadyDonated = useAlreadyDonatedToProject(projectData);
+
+	const isStellarOnlyRound =
+		activeStartedRound?.eligibleNetworks?.length === 1 &&
+		activeStartedRound?.eligibleNetworks[0] ===
+			config.STELLAR_NETWORK_NUMBER;
 
 	useEffect(() => {
 		const fetchProjectReaction = async () => {
@@ -132,7 +143,13 @@ export const ProjectPublicActions = () => {
 			)}
 			<Link
 				id='Donate_Project'
-				href={isActive ? slugToProjectDonate(slug || '') : '#'}
+				href={
+					isActive
+						? isStellarOnlyRound
+							? slugToProjectDonateStellar(slug || '')
+							: slugToProjectDonate(slug || '')
+						: '#'
+				}
 				onClick={e => !isActive && e.preventDefault()}
 				style={{ pointerEvents: !isActive ? 'none' : 'auto' }}
 			>

--- a/src/components/views/projects/ProjectsIndex.tsx
+++ b/src/components/views/projects/ProjectsIndex.tsx
@@ -39,6 +39,8 @@ import NotAvailable from '@/components/NotAvailable';
 import { fetchProjects, IQueries } from './services';
 import { IProject } from '@/apollo/types/types';
 import { LAST_PROJECT_CLICKED } from './constants';
+import { hasRoundStarted } from '@/helpers/qf';
+import config from '@/configuration';
 
 export interface IProjectsView {
 	projects: IProject[];
@@ -60,6 +62,9 @@ const ProjectsIndex = (props: IProjectsView) => {
 		isQF,
 		isArchivedQF,
 	} = useProjectsContext();
+
+	const activeRoundStarted = hasRoundStarted(activeQFRound);
+
 	const router = useRouter();
 	const lastElementRef = useRef<HTMLDivElement>(null);
 	const isInfiniteScrolling = useRef(true);
@@ -170,6 +175,13 @@ const ProjectsIndex = (props: IProjectsView) => {
 		sessionStorage.setItem(LAST_PROJECT_CLICKED, slug);
 	};
 
+	const isStellarOnlyQF =
+		activeRoundStarted &&
+		activeQFRound?.eligibleNetworks?.length === 1 &&
+		activeQFRound?.eligibleNetworks?.includes(
+			config.STELLAR_NETWORK_NUMBER,
+		);
+
 	// Scroll to last clicked project
 	useEffect(() => {
 		if (!isFetching && !isFetchingNextPage) {
@@ -218,11 +230,7 @@ const ProjectsIndex = (props: IProjectsView) => {
 					<Spinner />
 				</Loading>
 			)}
-			{isQF && (
-				<>
-					<PassportBanner />
-				</>
-			)}
+			{isQF && !isStellarOnlyQF && <PassportBanner />}
 			<Wrapper>
 				{isQF && !isArchivedQF && (
 					<>

--- a/src/components/views/userProfile/ProfileOverviewTab.tsx
+++ b/src/components/views/userProfile/ProfileOverviewTab.tsx
@@ -35,9 +35,10 @@ import { useProfileContext } from '@/context/profile.context';
 import { useIsSafeEnvironment } from '@/hooks/useSafeAutoConnect';
 import { useGeneralWallet } from '@/providers/generalWalletProvider';
 import { QFDonorEligibilityCard } from '@/components/views/userProfile/QFDonorEligibilityCard';
-import { getNowUnixMS } from '@/helpers/time';
 import { useFetchSubgraphDataForAllChains } from '@/hooks/useFetchSubgraphDataForAllChains';
 import ProjectsMiddleGivethVaultBanner from '../projects/MiddleBanners/ProjectsMiddleGivethVaultBanner';
+import config from '@/configuration';
+import { hasRoundStarted } from '@/helpers/qf';
 
 interface IBtnProps extends IButtonProps {
 	outline?: boolean;
@@ -118,10 +119,12 @@ const ProfileOverviewTab: FC<IUserProfileView> = () => {
 	const givPower = getTotalGIVpower(subgraphValues, address);
 	const { title, subtitle, buttons } = section;
 
-	const activeStartedRoundNotEnded =
-		activeQFRound &&
-		new Date(activeQFRound.beginDate).getTime() < getNowUnixMS() &&
-		new Date(activeQFRound.endDate).getTime() > getNowUnixMS();
+	const startedActiveRound = activeQFRound && hasRoundStarted(activeQFRound);
+
+	const isStellarOnlyQF =
+		startedActiveRound &&
+		activeQFRound.eligibleNetworks?.length === 1 &&
+		activeQFRound.eligibleNetworks?.includes(config.STELLAR_NETWORK_NUMBER);
 
 	useEffect(() => {
 		const setupSections = async () => {
@@ -208,7 +211,7 @@ const ProfileOverviewTab: FC<IUserProfileView> = () => {
 				) : (
 					<Row>
 						<Col lg={6}>
-							{activeStartedRoundNotEnded && (
+							{startedActiveRound && !isStellarOnlyQF && (
 								<QFDonorEligibilityCard />
 							)}
 						</Col>

--- a/src/hooks/usePassport.ts
+++ b/src/hooks/usePassport.ts
@@ -354,7 +354,7 @@ export const usePassport = () => {
 					passportState: EPassportState.NOT_CONNECTED,
 					passportScore: null,
 					activeQFMBDScore: null,
-					currentRound: null,
+					currentRound: activeQFRound,
 				});
 			}
 			console.log('******2', address, isUserFullFilled, user);

--- a/src/lib/routeCreators.tsx
+++ b/src/lib/routeCreators.tsx
@@ -12,6 +12,10 @@ export const slugToProjectDonate = (slug: string, recurring = false) => {
 	return Routes.Donate + '/' + slug + (recurring ? '?tab=recurring' : '');
 };
 
+export const slugToProjectDonateStellar = (slug: string) => {
+	return Routes.Donate + '/' + slug + '?chain=stellar';
+};
+
 export const idToProjectEdit = (id?: string) => {
 	return Routes.Project + '/' + id + '/edit';
 };


### PR DESCRIPTION
- https://github.com/Giveth/giveth-dapps-v2/issues/5116
- https://github.com/Giveth/giveth-dapps-v2/issues/5118
- https://github.com/Giveth/giveth-dapps-v2/issues/5119

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added support for Stellar-only funding rounds with a dedicated donation link.
	- Donation and network-switching buttons are hidden during Stellar-only rounds for a cleaner interface.
	- Introduced new localized messages prompting users to sign in for GIVbacks opportunities.
	- Enhanced eligibility badges and toast notifications to better reflect Stellar network participation.

- **Bug Fixes**
	- Refined display logic for donation options and eligibility indicators based on network eligibility.

- **Chores**
	- Extended data fetching to include eligible networks for each funding round.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->