### PR TITLE
fix share content for cause in cause single page

### DIFF
--- a/src/components/modals/ShareModal.tsx
+++ b/src/components/modals/ShareModal.tsx
@@ -30,6 +30,7 @@ import { fullPath } from '@/lib/helpers';
 import { useModalAnimation } from '@/hooks/useModalAnimation';
 import {
 	EContentType,
+	EContentTypeCause,
 	ESocialType,
 	shareContentCreator,
 	shareContentCreatorCause,
@@ -37,7 +38,7 @@ import {
 
 interface IShareModal extends IModal {
 	projectHref: string;
-	contentType: EContentType;
+	contentType: EContentType | EContentTypeCause;
 	shareTitle?: string | undefined;
 	shareDescription?: string | undefined;
 	isCause?: boolean;
@@ -66,14 +67,18 @@ const ShareModal: FC<IShareModal> = props => {
 				ESocialType.twitter,
 				numberOfProjects,
 			)
-		: shareContentCreator(contentType, ESocialType.twitter);
+		: shareContentCreator(contentType as EContentType, ESocialType.twitter);
+
 	const shareTitleFacebookAndLinkedin = isCause
 		? shareContentCreatorCause(
 				contentType,
 				ESocialType.facebook,
 				numberOfProjects,
 			)
-		: shareContentCreator(contentType, ESocialType.facebook);
+		: shareContentCreator(
+				contentType as EContentType,
+				ESocialType.facebook,
+			);
 
 	const shareModalTitle = formatMessage({
 		id: shareTitle || 'label.share_this',

--- a/src/components/views/project/projectActionCard/ProjectPublicActions.tsx
+++ b/src/components/views/project/projectActionCard/ProjectPublicActions.tsx
@@ -15,10 +15,11 @@ import { captureException } from '@sentry/nextjs';
 import { useIntl } from 'react-intl';
 import Link from 'next/link';
 import { useWeb3Modal } from '@web3modal/wagmi/react';
+import { EProjectType } from '@/apollo/types/gqlEnums';
 import useDetectDevice from '@/hooks/useDetectDevice';
 import ShareModal from '@/components/modals/ShareModal';
 import ShareLikeBadge from '@/components/badges/ShareLikeBadge';
-import { EContentType } from '@/lib/constants/shareContent';
+import { EContentType, EContentTypeCause } from '@/lib/constants/shareContent';
 import { useProjectContext } from '@/context/project.context';
 import { useAppSelector } from '@/features/hooks';
 import { isSSRMode, showToastError } from '@/lib/helpers';
@@ -177,7 +178,13 @@ export const ProjectPublicActions = () => {
 			</BadgeWrapper>
 			{showModal && slug && (
 				<ShareModal
-					contentType={EContentType.thisProject}
+					contentType={
+						project.projectType === EProjectType.CAUSE
+							? EContentTypeCause.detailsPage
+							: EContentType.thisProject
+					}
+					isCause={project.projectType === EProjectType.CAUSE}
+					numberOfProjects={project.causeProjects?.length || 0}
 					setShowModal={setShowShareModal}
 					projectHref={slug}
 				/>


### PR DESCRIPTION
cause success share link text and general share text for social media
[#5100](https://github.com/Giveth/giveth-dapps-v2/issues/5100)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced the sharing functionality to support both standard projects and cause-type projects, providing tailored share content based on project type.

* **Improvements**
  * The share modal now displays content and metadata that adapts depending on whether the shared project is a cause, improving clarity and relevance for users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->