### PR TITLE
Remove estimated matching from "donate" page

### DIFF
--- a/src/components/views/donate/DonatePageProjectDescription.tsx
+++ b/src/components/views/donate/DonatePageProjectDescription.tsx
@@ -24,7 +24,7 @@ import { ORGANIZATION } from '@/lib/constants/organizations';
 import { useDonateData } from '@/context/donate.context';
 import { ChainType } from '@/types/config';
 import config from '@/configuration';
-import { calculateTotalEstimatedMatching, getActiveRound } from '@/helpers/qf';
+import { getActiveRound } from '@/helpers/qf';
 import { GivBackBadge } from '@/components/badges/GivBackBadge';
 import links from '@/lib/constants/links';
 
@@ -138,25 +138,6 @@ export const DonatePageProjectDescription: FC<
 									)}
 								</LightSubline>
 							</div>
-							<EstimatedMatchingPrice>
-								+&nbsp;
-								{formatDonation(
-									calculateTotalEstimatedMatching(
-										projectDonationsSqrtRootSum,
-										allProjectsSum,
-										allocatedFundUSDPreferred
-											? allocatedFundUSD
-											: matchingPool,
-										activeStartedRound?.maximumReward,
-									),
-									allocatedFundUSDPreferred ? '$' : '',
-									locale,
-									true,
-								)}
-								{allocatedFundUSDPreferred
-									? ''
-									: ` ${allocatedTokenSymbol}`}
-							</EstimatedMatchingPrice>
 						</>
 					) : (
 						<DonateInfo>


### PR DESCRIPTION
Remove estimated matching from "donate" page during QF rounds #5147


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Removed the display of estimated matching amounts from the donation project description page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->