### PR TITLE
Disable opening a project as a cause and vice versa

### DIFF
--- a/pages/cause/[causeIdSlug]/index.tsx
+++ b/pages/cause/[causeIdSlug]/index.tsx
@@ -8,6 +8,7 @@ import { ICauseBySlug } from '@/apollo/types/gqlTypes';
 import { ProjectProvider } from '@/context/project.context';
 import { FETCH_PROJECT_BY_SLUG_SINGLE_PROJECT } from '@/apollo/gql/gqlProjects';
 import { ProjectMeta } from '@/components/Metatag';
+import { EProjectType } from '@/apollo/types/gqlEnums';
 
 const CauseRoute: FC<ICauseBySlug> = ({ cause }) => {
 	useReferral();
@@ -35,6 +36,16 @@ export async function getServerSideProps(props: {
 			variables: { slug },
 			fetchPolicy: 'no-cache',
 		});
+
+		// Perform redirect on server side for projects
+		if (data.projectBySlug?.projectType === EProjectType.PROJECT) {
+			return {
+				redirect: {
+					destination: `/project/${data.projectBySlug.slug}`,
+					permanent: false,
+				},
+			};
+		}
 
 		return {
 			props: {

--- a/pages/project/[projectIdSlug]/index.tsx
+++ b/pages/project/[projectIdSlug]/index.tsx
@@ -8,6 +8,7 @@ import ProjectIndex from '@/components/views/project/ProjectIndex';
 import { IProjectBySlug } from '@/apollo/types/gqlTypes';
 import { ProjectProvider } from '@/context/project.context';
 import { ProjectMeta } from '@/components/Metatag';
+import { EProjectType } from '@/apollo/types/gqlEnums';
 
 const ProjectRoute: FC<IProjectBySlug> = ({ project }) => {
 	useReferral();
@@ -35,6 +36,16 @@ export async function getServerSideProps(props: {
 			variables: { slug },
 			fetchPolicy: 'no-cache',
 		});
+
+		// Perform redirect on server side for causes
+		if (data.projectBySlug?.projectType === EProjectType.CAUSE) {
+			return {
+				redirect: {
+					destination: `/cause/${data.projectBySlug.slug}`,
+					permanent: false,
+				},
+			};
+		}
 
 		return {
 			props: {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic redirects between cause and project pages to ensure users are directed to the correct page type based on the entity selected. 

* **Bug Fixes**
  * Prevented incorrect rendering of cause or project pages when accessing an entity of the opposite type.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->