### PR TITLE
Improving user owner profile cause view

### DIFF
--- a/src/apollo/gql/gqlCauses.ts
+++ b/src/apollo/gql/gqlCauses.ts
@@ -501,6 +501,7 @@ export const FETCH_CAUSES_BY_USER_ID = gql`
 					id
 					projectId
 					isIncluded
+					userRemoved
 					project {
 						id
 						verified
@@ -516,10 +517,6 @@ export const FETCH_CAUSES_BY_USER_ID = gql`
 				}
 			}
 			totalCount
-			categories {
-				id
-				name
-			}
 			campaign {
 				id
 				title

--- a/src/apollo/gql/gqlCauses.ts
+++ b/src/apollo/gql/gqlCauses.ts
@@ -12,7 +12,6 @@ export const CAUSE_TITLE_IS_VALID_EDIT = `
 	}
 `;
 
-// Note: TypeGraphQL uses Float for numbers by default
 export const CREATE_CAUSE = gql`
 	mutation CreateCause(
 		$title: String!

--- a/src/apollo/gql/gqlCauses.ts
+++ b/src/apollo/gql/gqlCauses.ts
@@ -265,7 +265,6 @@ export const FETCH_CAUSE_BY_ID_EDIT = gql`
 `;
 
 export const FETCH_USER_CAUSES = gql`
-	${PROJECT_CARD_FIELDS_CAUSES}
 	query FetchUserProjects(
 		$take: Float
 		$skip: Float
@@ -282,7 +281,54 @@ export const FETCH_USER_CAUSES = gql`
 			projectType: $projectType
 		) {
 			projects {
-				...ProjectCardFields
+				id
+				title
+				slug
+				verified
+				isGivbackEligible
+				totalDonations
+				projectType
+				qfRounds {
+					id
+					name
+					isActive
+					beginDate
+					endDate
+				}
+				descriptionSummary
+				categories {
+					name
+					value
+					mainCategory {
+						title
+					}
+				}
+				verified
+				adminUser {
+					name
+					walletAddress
+				}
+				organization {
+					label
+				}
+				addresses {
+					address
+					memo
+					isRecipient
+					networkId
+					chainType
+				}
+				status {
+					name
+				}
+				sumDonationValueUsdForActiveQfRound
+				countUniqueDonorsForActiveQfRound
+				countUniqueDonors
+				estimatedMatching {
+					projectDonationsSqrtRootSum
+					allProjectsSum
+					matchingPool
+				}
 				creationDate
 				listed
 				activeProjectsCount
@@ -300,22 +346,6 @@ export const FETCH_USER_CAUSES = gql`
 					isRecipient
 					networkId
 					chainType
-				}
-				causeProjects {
-					id
-					projectId
-					isIncluded
-					project {
-						id
-						verified
-						status {
-							name
-						}
-						addresses {
-							id
-							networkId
-						}
-					}
 				}
 			}
 			totalCount
@@ -435,6 +465,62 @@ export const FETCH_CAUSE_BY_SLUG_SINGLE_CAUSE = gql`
 				allocatedFundUSD
 			}
 			campaigns {
+				id
+				title
+			}
+		}
+	}
+`;
+
+export const FETCH_CAUSES_BY_USER_ID = gql`
+	query FetchUserCauses($userId: Int!, $take: Float = 10, $skip: Float = 0) {
+		causesByUserId(userId: $userId, take: $take, skip: $skip) {
+			projects {
+				id
+				title
+				creationDate
+				listed
+				activeProjectsCount
+				status {
+					id
+					name
+				}
+				totalRaised
+				totalDistributed
+				ownerTotalEarned
+				ownerTotalEarnedUsdValue
+				projectType
+				addresses {
+					address
+					memo
+					isRecipient
+					networkId
+					chainType
+				}
+				causeProjects {
+					id
+					projectId
+					isIncluded
+					project {
+						id
+						verified
+						addresses {
+							id
+							networkId
+						}
+						status {
+							id
+							name
+						}
+					}
+				}
+			}
+			totalCount
+			categories {
+				id
+				name
+			}
+			campaign {
 				id
 				title
 			}

--- a/src/apollo/gql/gqlCauses.ts
+++ b/src/apollo/gql/gqlCauses.ts
@@ -243,6 +243,11 @@ export const FETCH_CAUSE_BY_ID_EDIT = gql`
 					status {
 						name
 					}
+					adminUser {
+						id
+						name
+						walletAddress
+					}
 				}
 			}
 			categories {

--- a/src/apollo/gql/gqlCauses.ts
+++ b/src/apollo/gql/gqlCauses.ts
@@ -302,7 +302,6 @@ export const FETCH_USER_CAUSES = gql`
 						title
 					}
 				}
-				verified
 				adminUser {
 					name
 					walletAddress
@@ -316,9 +315,6 @@ export const FETCH_USER_CAUSES = gql`
 					isRecipient
 					networkId
 					chainType
-				}
-				status {
-					name
 				}
 				sumDonationValueUsdForActiveQfRound
 				countUniqueDonorsForActiveQfRound

--- a/src/apollo/gql/gqlCauses.ts
+++ b/src/apollo/gql/gqlCauses.ts
@@ -477,6 +477,7 @@ export const FETCH_CAUSES_BY_USER_ID = gql`
 			projects {
 				id
 				title
+				slug
 				creationDate
 				listed
 				activeProjectsCount

--- a/src/components/views/userProfile/causesTab/ProfileCausesTab.tsx
+++ b/src/components/views/userProfile/causesTab/ProfileCausesTab.tsx
@@ -11,7 +11,7 @@ import { UserContributeTitle, UserProfileTab } from '../common.sc';
 import { CausesContributeCard } from '@/components/ContributeCard';
 import { useProfileContext } from '@/context/profile.context';
 import { getUserName } from '@/helpers/user';
-import { fetchUserCauses } from './services';
+import { fetchUserCauses, fetchUserCausesAdmin } from './services';
 import {
 	projectsOrder,
 	userProjectsPerPage,
@@ -26,9 +26,21 @@ const ProfileCausesTab: FC<IUserProfileView> = () => {
 	const isOwner = myAccount; // Determines if the logged-in user is the profile owner
 
 	const { data, isLoading, refetch } = useQuery({
-		queryKey: ['dashboard-causes', user.id, page, projectsOrder],
-		queryFn: () => fetchUserCauses(user.id!, page, projectsOrder),
-		enabled: !!user.id,
+		queryKey: ['dashboard-causes', user.id, page, myAccount, projectsOrder],
+		queryFn: async () => {
+			if (!user?.id) {
+				return { projects: [], totalCount: 0 };
+			}
+
+			// Admin (logged-in user) view
+			if (myAccount) {
+				return fetchUserCausesAdmin(user.id, page);
+			}
+
+			// Public view
+			return fetchUserCauses(user.id, page, projectsOrder);
+		},
+		enabled: !!user?.id,
 	});
 
 	return (

--- a/src/components/views/userProfile/causesTab/services.ts
+++ b/src/components/views/userProfile/causesTab/services.ts
@@ -1,5 +1,8 @@
 import { client } from '@/apollo/apolloClient';
-import { FETCH_USER_CAUSES } from '@/apollo/gql/gqlCauses';
+import {
+	FETCH_CAUSES_BY_USER_ID,
+	FETCH_USER_CAUSES,
+} from '@/apollo/gql/gqlCauses';
 import { IProject } from '@/apollo/types/types';
 import { IOrder } from '../projectsTab/type';
 import { userProjectsPerPage } from '../projectsTab/constants';
@@ -22,6 +25,22 @@ export const fetchUserCauses = async (
 		fetchPolicy: 'network-only',
 	});
 	return data.projectsByUserId as {
+		projects: IProject[];
+		totalCount: number;
+	};
+};
+
+export const fetchUserCausesAdmin = async (userId: string, page: number) => {
+	const { data } = await client.query({
+		query: FETCH_CAUSES_BY_USER_ID,
+		variables: {
+			userId: parseFloat(userId || '') || -1,
+			take: userProjectsPerPage,
+			skip: page * userProjectsPerPage,
+		},
+		fetchPolicy: 'network-only',
+	});
+	return data.causesByUserId as {
 		projects: IProject[];
 		totalCount: number;
 	};

--- a/src/components/views/userProfile/projectsTab/ProjectItem.tsx
+++ b/src/components/views/userProfile/projectsTab/ProjectItem.tsx
@@ -49,6 +49,8 @@ const ProjectItem: FC<IProjectItem> = props => {
 	const [showClaimModal, setShowClaimModal] = useState(false);
 	const [showDeleteModal, setShowDeleteModal] = useState(false);
 
+	console.log('project', project);
+
 	// Check does cause have some projects that has been not active
 	// or missing network 137 address
 	let projectStatus = '';

--- a/src/components/views/userProfile/projectsTab/ProjectItem.tsx
+++ b/src/components/views/userProfile/projectsTab/ProjectItem.tsx
@@ -49,8 +49,6 @@ const ProjectItem: FC<IProjectItem> = props => {
 	const [showClaimModal, setShowClaimModal] = useState(false);
 	const [showDeleteModal, setShowDeleteModal] = useState(false);
 
-	console.log('project', project);
-
 	// Check does cause have some projects that has been not active
 	// or missing network 137 address
 	let projectStatus = '';


### PR DESCRIPTION
This solve loading user admin profile cause tab faster.

First this need to be merged:

- https://github.com/Giveth/impact-graph/pull/2108

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the ability for profile owners (admins) to view a more detailed list of their causes, including additional project and campaign information.
  * Introduced a new query to fetch causes by user ID with enhanced details and pagination support.

* **Improvements**
  * Enhanced the user profile causes tab to differentiate between admin and public views, providing tailored data based on ownership status.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->