### PR TITLE
Fixing error on approving on Gnosis

### DIFF
--- a/src/components/views/donateCause/CauseDonateModal.tsx
+++ b/src/components/views/donateCause/CauseDonateModal.tsx
@@ -198,6 +198,10 @@ const CauseDonateModal: FC<IDonateModalProps> = props => {
 
 			if (squidRoute?.route) {
 				spenderAddress = squidRoute.route.transactionRequest.target;
+			} else {
+				setApproving(false);
+				setFailedModalType(EDonationFailedType.FAILED_LIQUIDITY);
+				return;
 			}
 		}
 


### PR DESCRIPTION
- https://github.com/Giveth/giveth-dapps-v2/issues/5250

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Introduced a dedicated “liquidity failure” state that displays a clear failure modal when insufficient liquidity is detected during donation approval.

- Bug Fixes
  - Prevents the approval process from proceeding when a required route is unavailable, avoiding confusing errors.
  - Stops showing generic failures by surfacing a specific liquidity-related error, improving clarity for users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->