### PR TITLE
Fixing showing verification email on public profile

### DIFF
--- a/src/components/views/userProfile/UserProfile.view.tsx
+++ b/src/components/views/userProfile/UserProfile.view.tsx
@@ -122,12 +122,14 @@ const UserProfileView: FC<IUserProfileView> = () => {
 				<H5>{formatMessage({ id: 'label.please_sign_in' })}</H5>
 			</NoUserContainer>
 		);
+
 	return (
 		<>
 			{user &&
 				myAccount &&
 				(user.projectsCount ?? 0) > 0 &&
-				!user?.isEmailVerified && (
+				!user?.isEmailVerified &&
+				router.pathname === Routes.MyAccount && (
 					<VerifyEmailBanner setShowModal={setShowModal} />
 				)}
 			<ProfileHeader>


### PR DESCRIPTION
- https://github.com/Giveth/giveth-dapps-v2/issues/5258

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Verify Email banner now appears only on the My Account page, and only when a user is signed in, has at least one project, and the email is unverified. This prevents the banner from showing on other pages and improves consistency.
  * No other UI or behavior changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->