### PR TITLE
QF Multi: remove "estimated matching" as sorting option

### DIFF
--- a/src/components/views/projects/sort/ProjectsSortSelect.tsx
+++ b/src/components/views/projects/sort/ProjectsSortSelect.tsx
@@ -13,7 +13,6 @@ import {
 	Caption,
 	Flex,
 	IconPublish16,
-	IconEstimated16,
 	IconGIVBack16,
 	IconSpark16,
 } from '@giveth/ui-design-system';
@@ -180,22 +179,12 @@ const ProjectsSortSelect = () => {
 
 		// Add QF-specific options if isQF is true
 		if (isQF) {
-			updatedOptions.splice(
-				updatedOptions.length - 1,
-				0,
-				{
-					label: formatMessage({ id: 'label.amount_raised_in_qf' }),
-					value: EProjectsSortBy.ActiveQfRoundRaisedFunds,
-					icon: <IconIncrease16 />,
-					color: semanticColors.jade[500],
-				},
-				{
-					label: formatMessage({ id: 'label.estimated_matching' }),
-					value: EProjectsSortBy.EstimatedMatching,
-					icon: <IconEstimated16 />,
-					color: semanticColors.jade[500],
-				},
-			);
+			updatedOptions.splice(updatedOptions.length - 1, 0, {
+				label: formatMessage({ id: 'label.amount_raised_in_qf' }),
+				value: EProjectsSortBy.ActiveQfRoundRaisedFunds,
+				icon: <IconIncrease16 />,
+				color: semanticColors.jade[500],
+			});
 		}
 
 		setSortByOptions(updatedOptions);


### PR DESCRIPTION
- https://github.com/Giveth/giveth-dapps-v2/issues/5330

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Removed the “Estimated Matching” sort option from QF-specific project sorting. “Active QF Round: Raised Funds” remains available alongside existing options. Default “Best Match” and other initial sorting behaviors are unchanged.

- Chores
  - Cleaned up an unused icon import in the projects sort component.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->