### PR TITLE
QF Multi: Limit round card text

### DIFF
--- a/src/components/views/QFRounds/QFRoundCard.tsx
+++ b/src/components/views/QFRounds/QFRoundCard.tsx
@@ -13,6 +13,7 @@ import {
 } from '@giveth/ui-design-system';
 import { useIntl } from 'react-intl';
 import Link from 'next/link';
+import { truncateText } from '@/lib/helpers';
 
 type Layout = 'horizontal' | 'grid';
 
@@ -60,7 +61,7 @@ export default function QFRoundCard({
 					<Content>
 						<Title $layout={layout}>{title}</Title>
 
-						<Desc>{description}</Desc>
+						<Desc>{truncateText(description, 220)}</Desc>
 
 						{matchingPoolUsd && (
 							<MetaGrid $layout={layout}>
@@ -118,7 +119,7 @@ export default function QFRoundCard({
 					</Media>
 
 					<Content>
-						<Desc>{description}</Desc>
+						<Desc>{truncateText(description, 100)}</Desc>
 						{startDate && endDate && (
 							<Dates $layout={layout}>
 								{startDate} – {endDate}

--- a/src/lib/helpers.ts
+++ b/src/lib/helpers.ts
@@ -791,3 +791,21 @@ export function generateRandomNonce(): number {
 
 	return nonce;
 }
+
+/**
+ * Truncates text to a maximum length
+ * @param text - The text to truncate
+ * @param maxLength - The maximum length of the text
+ * @param ellipsis - The ellipsis to use
+ * @returns The truncated text
+ */
+export const truncateText = (
+	text: string,
+	maxLength: number = 50,
+	ellipsis: string = '...',
+) => {
+	if (!text) return '';
+	return text.length > maxLength
+		? `${text.slice(0, maxLength)}${ellipsis}`
+		: text;
+};


### PR DESCRIPTION
- https://github.com/Giveth/giveth-dapps-v2/issues/5282

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Long descriptions in QF Round cards are now truncated to show concise previews, improving scanability in both horizontal and grid layouts.
  * Ensures consistent, clean presentation of content across views, reducing visual clutter for lengthy text.

* **Refactor**
  * Centralized text truncation logic to provide consistent behavior across components.
  * No changes to public interfaces or user settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->