### PR TITLE
QF Multi: On stellar show only stellar eligible rounds

### DIFF
--- a/src/components/views/donate/DonationCardQFRounds/DonationCardQFRounds.tsx
+++ b/src/components/views/donate/DonationCardQFRounds/DonationCardQFRounds.tsx
@@ -20,6 +20,12 @@ import {
 } from '../../donateCause/helpers';
 import config from '@/configuration';
 
+// Add text truncation utility function
+const truncateText = (text: string, maxLength: number = 50) => {
+	if (!text) return '';
+	return text.length > maxLength ? `${text.slice(0, maxLength)}...` : text;
+};
+
 const EmptyRound: IQFRound = {
 	id: '',
 	name: '',
@@ -62,10 +68,23 @@ export const DonationCardQFRounds = ({
 }) => {
 	const { status } = useSwitchChain();
 	const { formatMessage } = useIntl();
-	const activeQFRounds = useMemo(
-		() => getActiveQFRounds(project.qfRounds || []),
-		[project.qfRounds],
-	);
+	const activeQFRounds = useMemo(() => {
+		let rounds = getActiveQFRounds(project.qfRounds || []);
+
+		// Filter for Stellar network if it's QR donation
+		if (isQRDonation) {
+			rounds = rounds.filter(round =>
+				round.eligibleNetworks.includes(config.STELLAR_NETWORK_NUMBER),
+			);
+		}
+
+		// Truncate round names
+		return rounds.map(round => ({
+			...round,
+			name: truncateText(round.name, 20),
+		}));
+	}, [project.qfRounds, isQRDonation]);
+
 	const [isSmartSelect, setIsSmartSelect] = useState(false);
 	const [showQFRoundModal, setShowQFRoundModal] = useState(false);
 


### PR DESCRIPTION
- https://github.com/Giveth/giveth-dapps-v2/issues/5287

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - When donating via QR on the Stellar network, only eligible Quadratic Funding (QF) rounds are shown.

- Improvements
  - QF round names are now truncated for cleaner, more readable cards.
  - Active QF rounds update more accurately based on project data and donation method.
  - Smoother UI experience when switching projects or donation modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->