### PR TITLE
QF Multi: Fix Giveth donation

### DIFF
--- a/src/components/views/donate/OneTime/DonateModal.tsx
+++ b/src/components/views/donate/OneTime/DonateModal.tsx
@@ -256,9 +256,7 @@ const DonateModal: FC<IDonateModalProps> = props => {
 						symbol: token.symbol,
 						useDonationBox: true,
 						relevantDonationTxHash: firstHash,
-						qfRoundId: selectedQFRound?.id
-							? Number(selectedQFRound?.id)
-							: undefined,
+						qfRoundId: undefined, // we don't include Giveth in QF
 					})
 						.then(({ txHash: secondHash }) => {
 							if (!secondHash) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected one-time donation flow so secondary donations to Giveth are no longer linked to any Quadratic Funding round. This prevents incorrect QF attribution and ensures accurate reporting and transparency. Users making a split donation will see QF association only where applicable, with the Giveth portion excluded from QF rounds. UI and primary donation behavior remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->