### PR TITLE
QF Multi: fix total donations info on projects/causes page

### DIFF
--- a/src/components/project-card/ProjectCard.tsx
+++ b/src/components/project-card/ProjectCard.tsx
@@ -112,6 +112,10 @@ const ProjectCard = (props: IProjectCard) => {
 		router.pathname === '/cause/[causeIdSlug]' &&
 		router.query?.tab === 'projects';
 
+	const isListingInsideProjectsCausesAllPage =
+		router.pathname === '/projects/[slug]' ||
+		router.pathname === '/causes/[slug]';
+
 	const isGivbackEligibleCheck = isGivbackEligible || isGivbacksEligible;
 
 	const { activeStartedRound: checkActiveRound, activeQFRound } =
@@ -271,7 +275,22 @@ const ProjectCard = (props: IProjectCard) => {
 								}
 							/>
 						)}
+						{isListingInsideProjectsCausesAllPage && (
+							<ProjectCardTotalRaised
+								activeStartedRound={!!activeStartedRound}
+								totalDonations={getProjectTotalRaisedUSD(
+									project,
+								)}
+								sumDonationValueUsdForActiveQfRound={
+									project.totalDonations || 0
+								}
+								countUniqueDonors={countUniqueDonors || 0}
+								projectsCount={project.activeProjectsCount || 0}
+								isCause={projectType === EProjectType.CAUSE}
+							/>
+						)}
 						{!activeStartedRound &&
+							!isListingInsideProjectsCausesAllPage &&
 							!isListingInsideCauseProjectTabs && (
 								<ProjectCardTotalRaised
 									activeStartedRound={!!activeStartedRound}
@@ -289,7 +308,8 @@ const ProjectCard = (props: IProjectCard) => {
 								/>
 							)}
 						{activeStartedRound &&
-							!isListingInsideCauseProjectTabs && (
+							!isListingInsideCauseProjectTabs &&
+							!isListingInsideProjectsCausesAllPage && (
 								<ProjectCardTotalRaisedQF
 									activeStartedRound={!!activeStartedRound}
 									totalDonations={getProjectTotalRaisedUSD(


### PR DESCRIPTION
- https://github.com/Giveth/giveth-dapps-v2/issues/5305#issuecomment-3335911362

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Project cards now show total raised prominently when browsing the “All Projects” and “All Causes” listings.
* **Bug Fixes**
  * Prevented duplicate total-raised indicators in views where they shouldn’t appear.
* **Style**
  * Streamlined card header presentation on listing pages by prioritizing total raised information and hiding the active round badge in this context.
  * Preserved existing behaviors for cause tabs and eligibility indicators while adding a tailored total raised display for the all-pages listing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->