### PR TITLE
Fix non active round on active status not date

### DIFF
--- a/src/components/views/projects/ProjectsIndex.tsx
+++ b/src/components/views/projects/ProjectsIndex.tsx
@@ -54,6 +54,7 @@ const ProjectsIndex = (props: IProjectsView) => {
 	const user = useAppSelector(state => state.user.userData);
 	const { mainCategories } = useAppSelector(state => state.general);
 
+	// Check if the round is started
 	const [activeQFRound, setActiveQFRound] = useState<IQFRound | undefined>(
 		qfRound,
 	);
@@ -65,6 +66,9 @@ const ProjectsIndex = (props: IProjectsView) => {
 		if (qfRound) {
 			setActiveQFRound(qfRound);
 			setActiveRoundStarted(hasRoundStarted(qfRound) && qfRound.isActive);
+		} else {
+			setActiveQFRound(undefined);
+			setActiveRoundStarted(false);
 		}
 	}, [qfRound]);
 


### PR DESCRIPTION
- https://github.com/Giveth/giveth-dapps-v2/issues/5375

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Archived QF Projects banner shown on desktop when the active round hasn’t started.

- Bug Fixes
  - Active QF Projects banner now appears only after the round begins.
  - Prevents showing archived or active project banners prematurely; respects round-start status and mobile/desktop differences.

- Refactor
  - Simplified round-status handling in the Projects view for more predictable banner rendering and loading behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->