### PR TITLE
Increasing round name inside qf donation toast on success page

### DIFF
--- a/src/components/views/donate/DonationCardQFRounds/DonationCardQFRounds.tsx
+++ b/src/components/views/donate/DonationCardQFRounds/DonationCardQFRounds.tsx
@@ -79,10 +79,7 @@ export const DonationCardQFRounds = ({
 		}
 
 		// Truncate round names
-		return rounds.map(round => ({
-			...round,
-			name: truncateText(round.name, 20),
-		}));
+		return rounds;
 	}, [project.qfRounds, isQRDonation]);
 
 	const [isSmartSelect, setIsSmartSelect] = useState(false);


### PR DESCRIPTION
- https://github.com/Giveth/giveth-dapps-v2/pull/5391

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Full names of Quadratic Funding (QF) rounds are now shown in the active rounds section of the donation card; the previous 20-character truncation with ellipsis has been removed.
  * Improves readability of selected round labels, especially for longer names. Labels may occupy more horizontal space or wrap on small screens. Filtering and selection behavior remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->