### PR TITLE
Fix donation badge

### DIFF
--- a/src/components/views/donate/common/EligibilityBadges.tsx
+++ b/src/components/views/donate/common/EligibilityBadges.tsx
@@ -75,11 +75,11 @@ const EligibilityBadges: FC<IEligibilityBadges> = props => {
 		? 'page.donate.donations_will_be_matched'
 		: !isOnQFEligibleNetworks &&
 			  selectedQFRound &&
-			  selectedQFRound.eligibleNetworks.length > 0
+			  selectedQFRound.eligibleNetworks?.length > 0
 			? 'page.donate.network_not_eligible_for_qf'
 			: isOnQFEligibleNetworks &&
 				  selectedQFRound &&
-				  selectedQFRound.eligibleNetworks.length > 0
+				  selectedQFRound.eligibleNetworks?.length > 0
 				? 'page.donate.unlocks_matching_funds'
 				: null; // Prevents invalid id values
 
@@ -89,7 +89,8 @@ const EligibilityBadges: FC<IEligibilityBadges> = props => {
 			{/* Prevents QF Badge from rendering when !isOnQFEligibleNetworks && !activeStartedRound */}
 			{!(
 				isOnQFEligibleNetworks ||
-				(selectedQFRound && selectedQFRound.eligibleNetworks.length > 0)
+				(selectedQFRound &&
+					selectedQFRound.eligibleNetworks?.length > 0)
 			) ? null : (
 				<BadgesBase
 					warning={qfEligibleWarning}

--- a/src/components/views/donate/common/EligibilityBadges.tsx
+++ b/src/components/views/donate/common/EligibilityBadges.tsx
@@ -73,9 +73,13 @@ const EligibilityBadges: FC<IEligibilityBadges> = props => {
 	//  Define messageId BEFORE rendering to avoid issues
 	const messageId = isDonationMatched
 		? 'page.donate.donations_will_be_matched'
-		: !isOnQFEligibleNetworks && selectedQFRound
+		: !isOnQFEligibleNetworks &&
+			  selectedQFRound &&
+			  selectedQFRound.eligibleNetworks.length > 0
 			? 'page.donate.network_not_eligible_for_qf'
-			: isOnQFEligibleNetworks && selectedQFRound
+			: isOnQFEligibleNetworks &&
+				  selectedQFRound &&
+				  selectedQFRound.eligibleNetworks.length > 0
 				? 'page.donate.unlocks_matching_funds'
 				: null; // Prevents invalid id values
 
@@ -83,7 +87,10 @@ const EligibilityBadges: FC<IEligibilityBadges> = props => {
 		(isStellar && isStellarOnlyRound && !isProjectGivbacksEligible) ? (
 		<EligibilityBadgeWrapper style={style}>
 			{/* Prevents QF Badge from rendering when !isOnQFEligibleNetworks && !activeStartedRound */}
-			{!(isOnQFEligibleNetworks || selectedQFRound) ? null : (
+			{!(
+				isOnQFEligibleNetworks ||
+				(selectedQFRound && selectedQFRound.eligibleNetworks.length > 0)
+			) ? null : (
 				<BadgesBase
 					warning={qfEligibleWarning}
 					active={isDonationMatched}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * QF eligibility badges and messages now require a confirmed non-empty list of eligible networks before appearing.
  * Prevents misleading “network not eligible for QF” or “unlocks matching funds” messages when eligibility data is missing or incomplete.
  * Fixes edge cases where QF badges could be incorrectly shown or hidden, improving clarity for donors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->