### PR TITLE
Fix archived rounds and back button on donation success

### DIFF
--- a/pages/qf/[slug].tsx
+++ b/pages/qf/[slug].tsx
@@ -35,7 +35,7 @@ export const getServerSideProps: GetServerSideProps = async context => {
 		const { query } = context;
 		const slug = query.slug as string;
 
-		// GEt round data from database
+		// Get round data from database
 		const roundData = await getQFRoundData(slug);
 
 		const apolloClient = initializeApollo();

--- a/src/apollo/gql/gqlCauses.ts
+++ b/src/apollo/gql/gqlCauses.ts
@@ -130,6 +130,7 @@ export const PROJECT_CORE_FIELDS_CAUSES_ALL = gql`
 		projectType
 		qfRounds {
 			id
+			slug
 			name
 			isActive
 			beginDate
@@ -454,6 +455,7 @@ export const FETCH_CAUSE_BY_SLUG_SINGLE_CAUSE = gql`
 			}
 			qfRounds {
 				id
+				slug
 				name
 				isActive
 				beginDate

--- a/src/apollo/gql/gqlProjects.ts
+++ b/src/apollo/gql/gqlProjects.ts
@@ -19,6 +19,7 @@ export const PROJECT_CORE_FIELDS = gql`
 		}
 		qfRounds {
 			id
+			slug
 			name
 			isActive
 			beginDate
@@ -212,6 +213,7 @@ export const FETCH_PROJECT_BY_SLUG_DONATION = gql`
 			}
 			qfRounds {
 				id
+				slug
 				name
 				isActive
 				beginDate
@@ -312,6 +314,7 @@ export const FETCH_PROJECT_BY_SLUG_SINGLE_PROJECT = gql`
 			}
 			qfRounds {
 				id
+				slug
 				name
 				isActive
 				beginDate

--- a/src/components/project-card/ProjectCard.tsx
+++ b/src/components/project-card/ProjectCard.tsx
@@ -206,7 +206,6 @@ const ProjectCard = (props: IProjectCard) => {
 
 		calculateTotalAmountStreamed();
 	}, [props]);
-	console.log('project', project);
 
 	return (
 		// </Link>

--- a/src/components/project-card/ProjectCard.tsx
+++ b/src/components/project-card/ProjectCard.tsx
@@ -206,6 +206,7 @@ const ProjectCard = (props: IProjectCard) => {
 
 		calculateTotalAmountStreamed();
 	}, [props]);
+	console.log('project', project);
 
 	return (
 		// </Link>

--- a/src/components/views/QFRounds/QFRoundsIndex.tsx
+++ b/src/components/views/QFRounds/QFRoundsIndex.tsx
@@ -123,7 +123,7 @@ const QFRoundsIndex = () => {
 									round.endDate,
 									locale,
 								)}
-								linkUrl={`/qf/${round.slug}`}
+								linkUrl={`/qf-archive/${round.slug}`}
 							/>
 						))}
 					</QFRoundsWrapper>

--- a/src/components/views/donate/DonateHeader.tsx
+++ b/src/components/views/donate/DonateHeader.tsx
@@ -26,7 +26,6 @@ import { useDonateData } from '@/context/donate.context';
 import { EScrollDir, useScrollDetection } from '@/hooks/useScrollDetection';
 import { useGeneralWallet } from '@/providers/generalWalletProvider';
 import { setShowWelcomeModal } from '@/features/modal/modal.slice';
-import { getActiveRound } from '@/helpers/qf';
 
 export interface IHeader {
 	theme?: ETheme;
@@ -42,7 +41,7 @@ export const DonateHeader: FC<IHeader> = props => {
 	const dispatch = useAppDispatch();
 	const router = useRouter();
 
-	const { project } = useDonateData();
+	const { project, selectedQFRound } = useDonateData();
 	const scrollDir = useScrollDetection();
 
 	const isGIVeconomyRoute = checkIsGIVeconomyRoute(router.route);
@@ -51,12 +50,9 @@ export const DonateHeader: FC<IHeader> = props => {
 
 	// Change route if donation done successfully
 	if (isSuccessDonation) {
-		const { qfRounds } = project;
-		const { activeQFRound } = getActiveRound(qfRounds);
-
-		const isActiveQF = activeQFRound?.isActive;
-
-		routePath = isActiveQF ? Routes.QFProjects : Routes.AllProjects;
+		routePath = selectedQFRound
+			? Routes.QFProjects + '/' + selectedQFRound.slug
+			: Routes.AllProjects;
 	}
 
 	return (

--- a/src/components/views/donate/QFToast.tsx
+++ b/src/components/views/donate/QFToast.tsx
@@ -109,7 +109,11 @@ const QFToast: FC<IQFToast> = ({
 							buttonType='primary'
 							size='small'
 							icon={<IconExternalLink16 />}
-							onClick={() => router.push('/qf')}
+							onClick={() =>
+								selectedQFRound
+									? router.push(`/qf/${selectedQFRound.slug}`)
+									: router.push('/qf')
+							}
 						/>
 					</FlexCenter>
 				) : (

--- a/src/components/views/donateCause/CauseDonateHeader.tsx
+++ b/src/components/views/donateCause/CauseDonateHeader.tsx
@@ -26,7 +26,6 @@ import { useCauseDonateData } from '@/context/donate.cause.context';
 import { EScrollDir, useScrollDetection } from '@/hooks/useScrollDetection';
 import { useGeneralWallet } from '@/providers/generalWalletProvider';
 import { setShowWelcomeModal } from '@/features/modal/modal.slice';
-import { getActiveRound } from '@/helpers/qf';
 
 export interface IHeader {
 	theme?: ETheme;
@@ -42,7 +41,7 @@ export const CauseDonateHeader: FC<IHeader> = props => {
 	const dispatch = useAppDispatch();
 	const router = useRouter();
 
-	const { project } = useCauseDonateData();
+	const { project, selectedQFRound } = useCauseDonateData();
 	const scrollDir = useScrollDetection();
 
 	const isGIVeconomyRoute = checkIsGIVeconomyRoute(router.route);
@@ -51,12 +50,9 @@ export const CauseDonateHeader: FC<IHeader> = props => {
 
 	// Change route if donation done successfully
 	if (isSuccessDonation) {
-		const { qfRounds } = project;
-		const { activeQFRound } = getActiveRound(qfRounds);
-
-		const isActiveQF = activeQFRound?.isActive;
-
-		routePath = isActiveQF ? Routes.QFProjects : Routes.AllCauses;
+		routePath = selectedQFRound
+			? Routes.QFProjects + '/' + selectedQFRound.slug
+			: Routes.AllCauses;
 	}
 
 	return (

--- a/src/components/views/projects/ProjectsIndex.tsx
+++ b/src/components/views/projects/ProjectsIndex.tsx
@@ -136,6 +136,7 @@ const ProjectsIndex = (props: IProjectsView) => {
 			selectedMainCategory,
 			isQF,
 			qfRound?.id,
+			router.query.slug,
 		],
 		queryFn: fetchProjectsPage,
 		getNextPageParam: lastPage => lastPage.nextCursor,

--- a/src/components/views/projects/services.ts
+++ b/src/components/views/projects/services.ts
@@ -52,6 +52,7 @@ export const fetchProjects = async (
 				: getMainCategorySlug(selectedMainCategory),
 			qfRoundSlug: isArchivedQF ? routerQuerySlug : null,
 		},
+		fetchPolicy: 'no-cache',
 	});
 
 	let projectsData = [];


### PR DESCRIPTION
- https://github.com/Giveth/giveth-dapps-v2/issues/5399

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Direct navigation to specific QF rounds via slug from donation success and toast actions.
  - Archived QF rounds now open at /qf-archive/{slug}.

- Refactor
  - Donation headers simplified to use the selected QF round for post-donation routing.

- Improvements
  - Projects listing and pagination now respect the current round slug.
  - Fresher project data by bypassing cache during fetches.

- Data
  - QF round slugs added to project and cause queries to enable slug-based routing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->