### PR TITLE
Fixing loading more projects on QF Round page

### DIFF
--- a/src/components/views/projects/ProjectsIndex.tsx
+++ b/src/components/views/projects/ProjectsIndex.tsx
@@ -95,8 +95,8 @@ const ProjectsIndex = (props: IProjectsView) => {
 				: EProjectType.PROJECT;
 
 		const variables: IQueries = {
-			limit: 20, // Adjust the limit as needed
-			skip: 20 * pageParam,
+			limit: 15, // Adjust the limit as needed
+			skip: 15 * pageParam,
 			projectType,
 		};
 


### PR DESCRIPTION
- https://github.com/Giveth/giveth-dapps-v2/issues/5432

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Adjusted pagination page size in the Projects list from 20 to 15 items per page. This results in smaller batches of results per page, making pages lighter and potentially reducing load time. Navigation between pages remains the same; only the number of items shown per page has changed. Existing saved links and filters continue to work as before.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->