### PR TITLE
Fixing project card on active round

### DIFF
--- a/src/components/project-card/ProjectCard.tsx
+++ b/src/components/project-card/ProjectCard.tsx
@@ -305,22 +305,25 @@ const ProjectCard = (props: IProjectCard) => {
 								isCause={projectType === EProjectType.CAUSE}
 							/>
 						)}
-						{providedQFRoundId && (
-							<ProjectCardTotalRaised
-								activeStartedRound={true}
-								totalDonations={getProjectTotalRaisedUSD(
-									project,
-								)}
-								sumDonationValueUsdForActiveQfRound={getSumDonationValueUsdForActiveQfRound(
-									project,
-								)}
-								countUniqueDonors={getCountUniqueDonorsForActiveQfRound(
-									project,
-								)}
-								projectsCount={project.activeProjectsCount || 0}
-								isCause={projectType === EProjectType.CAUSE}
-							/>
-						)}
+						{(providedQFRoundId ?? 0) > 0 &&
+							!activeStartedRound && (
+								<ProjectCardTotalRaised
+									activeStartedRound={true}
+									totalDonations={getProjectTotalRaisedUSD(
+										project,
+									)}
+									sumDonationValueUsdForActiveQfRound={getSumDonationValueUsdForActiveQfRound(
+										project,
+									)}
+									countUniqueDonors={getCountUniqueDonorsForActiveQfRound(
+										project,
+									)}
+									projectsCount={
+										project.activeProjectsCount || 0
+									}
+									isCause={projectType === EProjectType.CAUSE}
+								/>
+							)}
 						{!activeStartedRound &&
 							!providedQFRoundId &&
 							!isListingInsideProjectsCausesAllPage &&


### PR DESCRIPTION
Fixing problem that @laurenluz reported on active round related to the project card inside it:

<img width="678" height="328" alt="Screenshot 2025-11-10 at 09 43 00" src="https://github.com/user-attachments/assets/2a9a02ef-e6b2-46f9-bec8-e9b05c7da3bd" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted when project total raised information displays to prevent showing outdated values during active fundraising rounds, while maintaining previous behavior for other scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->