### PR TITLE
Redirect QF pages to the new V6 QF

### DIFF
--- a/pages/qf/[slug].tsx
+++ b/pages/qf/[slug].tsx
@@ -1,4 +1,9 @@
 import { GetServerSideProps } from 'next/types';
+import Routes from '@/lib/constants/Routes';
+
+/*
+Old local QF round page implementation kept here for reference.
+
 import { EProjectsFilter } from '@/apollo/types/types';
 import { transformGraphQLErrorsToStatusCode } from '@/helpers/requests';
 import { initializeApollo } from '@/apollo/apolloClient';
@@ -93,3 +98,17 @@ export const getServerSideProps: GetServerSideProps = async context => {
 };
 
 export default QFProjectsCategoriesRoute;
+*/
+
+export const getServerSideProps: GetServerSideProps = async context => {
+	return {
+		redirect: {
+			destination: Routes.QFProjects,
+			permanent: false,
+		},
+	};
+};
+
+export default function QFProjectsRedirect() {
+	return null;
+}

--- a/pages/qf/index.tsx
+++ b/pages/qf/index.tsx
@@ -1,14 +1,31 @@
-import React from 'react';
-import { projectsQFRoundMetatags } from '@/content/metatags';
-import { GeneralMetatags } from '@/components/Metatag';
-import { QFRoundsProvider } from '@/context/qfrounds.context';
-import QFRoundsIndex from '@/components/views/QFRounds/QFRoundsIndex';
+import { GetServerSideProps } from 'next/types';
+import Routes from '@/lib/constants/Routes';
 
-export default function QfLanding() {
-	return (
-		<QFRoundsProvider>
-			<GeneralMetatags info={projectsQFRoundMetatags} />
-			<QFRoundsIndex />
-		</QFRoundsProvider>
-	);
+// Old local QF landing page implementation kept here for reference.
+// import React from 'react';
+// import { projectsQFRoundMetatags } from '@/content/metatags';
+// import { GeneralMetatags } from '@/components/Metatag';
+// import { QFRoundsProvider } from '@/context/qfrounds.context';
+// import QFRoundsIndex from '@/components/views/QFRounds/QFRoundsIndex';
+//
+// export default function QfLanding() {
+// 	return (
+// 		<QFRoundsProvider>
+// 			<GeneralMetatags info={projectsQFRoundMetatags} />
+// 			<QFRoundsIndex />
+// 		</QFRoundsProvider>
+// 	);
+// }
+
+export const getServerSideProps: GetServerSideProps = async () => {
+	return {
+		redirect: {
+			destination: Routes.QFProjects,
+			permanent: false,
+		},
+	};
+};
+
+export default function QfLandingRedirect() {
+	return null;
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated navigation: The QF rounds landing page and QF projects categories page now redirect to the unified QF projects page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->