### PR TITLE
Render featured project update via RichTextViewer (XSS fix)

### DIFF
--- a/src/components/views/homepage/projectUpdatesBlock/ProjectUpdateSlide.tsx
+++ b/src/components/views/homepage/projectUpdatesBlock/ProjectUpdateSlide.tsx
@@ -1,4 +1,5 @@
 import React, { FC, useEffect, useRef, useState } from 'react';
+import dynamic from 'next/dynamic';
 import styled from 'styled-components';
 import {
 	B,
@@ -7,7 +8,6 @@ import {
 	H6,
 	IconChevronRight32,
 	neutralColors,
-	P,
 	Flex,
 	FlexCenter,
 } from '@giveth/ui-design-system';
@@ -20,6 +20,11 @@ import { client } from '@/apollo/apolloClient';
 import { FETCH_FEATURED_PROJECT_UPDATES } from '@/apollo/gql/gqlProjects';
 import Routes from '@/lib/constants/Routes';
 import { EProjectPageTabs } from '../../project/ProjectIndex';
+
+const RichTextViewer = dynamic(
+	() => import('@/components/rich-text/RichTextViewer'),
+	{ ssr: false },
+);
 
 interface IProjectUpdateSlideProps {
 	project: IProject;
@@ -88,11 +93,9 @@ export const ProjectUpdateSlide: FC<IProjectUpdateSlideProps> = ({
 								: ''}
 						</UpdateDate>
 						<UpdateTitle weight={700}>{update?.title}</UpdateTitle>
-						<UpdateDesc
-							dangerouslySetInnerHTML={{
-								__html: update?.content || '',
-							}}
-						/>
+						<UpdateDesc>
+							<RichTextViewer content={update?.content} />
+						</UpdateDesc>
 						<Flex $justifyContent='flex-end'>
 							<Link
 								href={`${Routes.Project}/${project.slug}?tab=${EProjectPageTabs.UPDATES}`}
@@ -150,7 +153,7 @@ const UpdateTitle = styled(H6)`
 	margin-bottom: 8px;
 `;
 
-const UpdateDesc = styled(P)`
+const UpdateDesc = styled.div`
 	color: ${neutralColors.gray[900]};
 	margin-bottom: 8px;
 	height: 290px;


### PR DESCRIPTION
## Summary
- The featured project update card on the homepage was rendering the backend `featuredProjectUpdate.content` field through `dangerouslySetInnerHTML` ([ProjectUpdateSlide.tsx:96-100](src/components/views/homepage/projectUpdatesBlock/ProjectUpdateSlide.tsx)). That content is controlled by the project owner, so a crafted update (e.g. `<img src=x onerror=…>`, `<a href="javascript:…">`) executed script in the `giveth.io` origin against every homepage visitor — same-origin `localStorage` reads (auth tokens), wallet-phishing prompts, or authenticated GraphQL calls as the victim.
- Replace `dangerouslySetInnerHTML` with the existing `RichTextViewer` (ReactQuill, read-only bubble theme) which is the same path already used to render update bodies in the project view at `UpdatesSection.tsx`. Quill does not interpret event handlers or `javascript:` URLs.
- A companion backend PR ([Giveth/impact-graph#2324](https://github.com/Giveth/impact-graph/pull/2324)) adds a strict allowlist sanitizer on `addProjectUpdate` / `editProjectUpdate` so this is defense in depth.

## Test plan
- [ ] Featured project update card on the homepage renders the formatted body correctly (text, bold, lists, links, images, YouTube embed)
- [ ] Editing a featured update with a malicious payload (`<img src=x onerror=alert(1)>` etc.) no longer fires once this PR + the backend PR are deployed
- [ ] Read More link to the project page is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced the rendering mechanism for project update descriptions to improve code stability and maintainability. The visual appearance and user experience remain unchanged.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Giveth/giveth-dapps-v2/pull/5562?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->