### PR TITLE
Fix/5574 stellar estimated matching

### DIFF
--- a/src/components/views/donate/DonationCardQFRounds/DonationCardQFRounds.tsx
+++ b/src/components/views/donate/DonationCardQFRounds/DonationCardQFRounds.tsx
@@ -86,11 +86,15 @@ export const DonationCardQFRounds = ({
 	const [showQFRoundModal, setShowQFRoundModal] = useState(false);
 
 	// Fetch QF round smart selection data
+	// Stellar (QR) donations are not tied to a connected EVM chain, so enable
+	// the query using the Stellar network number rather than requiring chainId.
 	const { data: smartSelectData, isFetching: isFetchingSmartSelect } =
 		useFetchQFRoundSmartSelect(
 			project.id ? parseInt(project.id) : 0,
 			isQRDonation ? config.STELLAR_NETWORK_NUMBER : chainId,
-			!!project.id && !!chainId && activeQFRounds.length > 0,
+			!!project.id &&
+				(isQRDonation || !!chainId) &&
+				activeQFRounds.length > 0,
 		);
 
 	const handleRoundSelect = (round: IQFRound) => {
@@ -144,9 +148,12 @@ export const DonationCardQFRounds = ({
 			}
 		} else if (
 			activeQFRounds.length > 0 &&
-			activeQFRounds[0].eligibleNetworks.includes(chainId)
+			activeQFRounds[0].eligibleNetworks.includes(
+				isQRDonation ? config.STELLAR_NETWORK_NUMBER : chainId,
+			)
 		) {
-			// Fallback to first active round if no smart selection and same chain is eligible
+			// Fallback to first active round if no smart selection and the
+			// network is eligible (Stellar network for QR donations).
 			setSelectedQFRound(activeQFRounds[0]);
 		} else {
 			setSelectedQFRound(EmptyRound);
@@ -177,6 +184,7 @@ export const DonationCardQFRounds = ({
 		chainId,
 		setSelectedQFRound,
 		choosedModalRound,
+		isQRDonation,
 	]);
 
 	// Return nothing if there are no QF rounds

--- a/src/components/views/donate/OneTime/SelectTokenModal/QRCodeDonation/QRDonationCard.tsx
+++ b/src/components/views/donate/OneTime/SelectTokenModal/QRCodeDonation/QRDonationCard.tsx
@@ -8,7 +8,6 @@ import {
 	neutralColors,
 	IconArrowLeft,
 	mediaQueries,
-	IconWalletOutline24,
 	OutlineButton,
 	IconArrowRight16,
 	Button,
@@ -21,7 +20,6 @@ import { ethers } from 'ethers';
 import {
 	InputWrapper,
 	SelectTokenWrapper,
-	BadgesBase,
 	ForEstimatedMatchingAnimation,
 } from '../../../common/common.styled';
 import { TokenIconWithGIVBack } from '../../../TokenIcon/TokenIconWithGIVBack';
@@ -43,7 +41,6 @@ import StorageLabel from '@/lib/localStorage';
 import InlineToast, { EToastType } from '@/components/toasts/InlineToast';
 import { useAppSelector } from '@/features/hooks';
 import { useModalCallback } from '@/hooks/useModalCallback';
-import { useGeneralWallet } from '@/providers/generalWalletProvider';
 import EligibilityBadges from '@/components/views/donate/common/EligibilityBadges';
 import EstimatedMatchingToast from '../../EstimatedMatchingToast';
 
@@ -73,7 +70,6 @@ export const QRDonationCard: FC<QRDonationCardProps> = ({
 	const { modalCallback: signInThenDonate } = useModalCallback(() =>
 		setShowDonateModal(true),
 	);
-	const { isConnected, chain } = useGeneralWallet();
 
 	const {
 		project,
@@ -94,7 +90,7 @@ export const QRDonationCard: FC<QRDonationCardProps> = ({
 		retrieveDraftDonation,
 	} = useQRCodeDonation(project);
 
-	const { addresses, id, isGivbackEligible } = project;
+	const { addresses, id } = project;
 	const draftDonationId = Number(router.query.draft_donation!);
 	const [amount, setAmount] = useState(0n);
 	const [usdAmount, setUsdAmount] = useState(0);
@@ -110,34 +106,6 @@ export const QRDonationCard: FC<QRDonationCardProps> = ({
 	const isOnEligibleNetworks = selectedQFRound?.eligibleNetworks?.includes(
 		config.STELLAR_NETWORK_NUMBER,
 	);
-	const isProjectGivbacksEligible = !!isGivbackEligible;
-	const isInQF = !!isOnEligibleNetworks;
-	const showConnectWallet = isProjectGivbacksEligible || isInQF;
-
-	const textToDisplayOnConnect = () => {
-		const onlyInQF =
-			selectedQFRound?.eligibleNetworks?.length === 1 &&
-			selectedQFRound?.eligibleNetworks[0] ===
-				config.STELLAR_NETWORK_NUMBER;
-
-		if (isProjectGivbacksEligible && onlyInQF) {
-			return 'label.sign_into_giveth_for_a_chance_to_win_givbacks';
-		}
-
-		if (isProjectGivbacksEligible && isInQF && !!selectedQFRound) {
-			return 'label.please_connect_your_wallet_to_win_givbacks_and_match';
-		}
-
-		if (isProjectGivbacksEligible) {
-			return 'label.sign_into_giveth_for_a_chance_to_win_givbacks';
-		}
-
-		if (!onlyInQF) {
-			return 'label.please_connect_your_wallet_to_match';
-		}
-
-		return null;
-	};
 
 	const donationUsdValue =
 		(tokenPrice || 0) * Number(ethers.utils.formatEther(amount));
@@ -311,9 +279,11 @@ export const QRDonationCard: FC<QRDonationCardProps> = ({
 		fetchTokenPrice();
 	}, []);
 
+	// Stellar QR donations don't connect an EVM/Solana wallet, so `chain` is
+	// always undefined here. The estimated matching is computed purely from
+	// project data + amount, so show it regardless of wallet/sign-in state.
 	const showEstimatedMatching =
 		!showQRCode &&
-		!!chain &&
 		selectedQFRound &&
 		!!selectedQFRound?.eligibleNetworks?.includes(
 			config.NON_EVM_NETWORKS_CONFIG[ChainType.STELLAR].networkId,
@@ -343,17 +313,6 @@ export const QRDonationCard: FC<QRDonationCardProps> = ({
 					})}
 				/>
 			)}
-			{!showQRCode &&
-				!isConnected &&
-				showConnectWallet &&
-				textToDisplayOnConnect() && (
-					<ConnectWallet>
-						<IconWalletOutline24 color={neutralColors.gray[700]} />
-						{formatMessage({
-							id: textToDisplayOnConnect() || '',
-						})}
-					</ConnectWallet>
-				)}
 			{!showQRCode && (
 				<EligibilityBadges
 					amount={amount}
@@ -467,10 +426,6 @@ export const QRDonationCard: FC<QRDonationCardProps> = ({
 		</>
 	);
 };
-
-const ConnectWallet = styled(BadgesBase)`
-	margin-bottom: 5px;
-`;
 
 const CardHead = styled(Flex)`
 	align-items: center;

--- a/src/components/views/donate/common/EligibilityBadges.tsx
+++ b/src/components/views/donate/common/EligibilityBadges.tsx
@@ -66,10 +66,6 @@ const EligibilityBadges: FC<IEligibilityBadges> = props => {
 		isProjectGivbacksEligible &&
 		donationUsdValue >= GIVBACKS_DONATION_QUALIFICATION_VALUE_USD;
 
-	const isStellarOnlyRound =
-		selectedQFRound?.eligibleNetworks?.length === 1 &&
-		selectedQFRound?.eligibleNetworks[0] === config.STELLAR_NETWORK_NUMBER;
-
 	//  Define messageId BEFORE rendering to avoid issues
 	const messageId = isDonationMatched
 		? 'page.donate.donations_will_be_matched'
@@ -83,8 +79,9 @@ const EligibilityBadges: FC<IEligibilityBadges> = props => {
 				? 'page.donate.unlocks_matching_funds'
 				: null; // Prevents invalid id values
 
-	return isConnected ||
-		(isStellar && isStellarOnlyRound && !isProjectGivbacksEligible) ? (
+	// Stellar (QR) donations don't require a connected wallet, so always show
+	// the eligibility badges for the Stellar flow — same as a connected wallet.
+	return isConnected || isStellar ? (
 		<EligibilityBadgeWrapper style={style}>
 			{/* Prevents QF Badge from rendering when !isOnQFEligibleNetworks && !activeStartedRound */}
 			{!(


### PR DESCRIPTION
## Issue

#5574

## Summary

This PR fixes the Stellar QR donation flow so logged-out users can see estimated matching information without needing an EVM/Solana wallet connection. Estimated matching and QF eligibility are now based on the selected Stellar round, project data, and donation amount, while the existing sign-in requirement for donation submission and Givebacks-specific behavior remains separate.

## Changes

- Enabled QF round smart selection for Stellar QR donations by using the Stellar network ID instead of requiring a connected wallet chain.
- Updated Stellar QF round fallback selection to validate against the Stellar network when no smart-select round is returned.
- Removed the QR donation wallet-connection gate that prevented estimated matching from displaying for logged-out users.
- Show eligibility badges in the Stellar QR flow without requiring a connected wallet, matching the behavior needed for QR donations.
- Kept the estimated matching calculation tied to the selected Stellar QF round, token price, and donation amount.

## How to Test

Please verify and adjust these steps if needed:

1. Open a project that accepts Stellar QR donations and is eligible for an active QF round with Stellar support.
2. Log out or use an unauthenticated browser session.
3. Start a Stellar QR donation flow from the project donate page.
4. Enter an amount that meets the selected QF round minimum.
5. Confirm the eligibility badges and Estimated Matching box are visible without connecting a wallet or signing in.
6. Confirm the estimated matching value appears based on the entered amount.
7. Continue to the next step and verify sign-in/Givebacks behavior is still handled separately where required.