### PR TITLE
Remove badges for non connected user on Stellar donation page

### DIFF
--- a/src/components/views/donate/OneTime/SelectTokenModal/QRCodeDonation/QRDonationCard.tsx
+++ b/src/components/views/donate/OneTime/SelectTokenModal/QRCodeDonation/QRDonationCard.tsx
@@ -8,6 +8,7 @@ import {
 	neutralColors,
 	IconArrowLeft,
 	mediaQueries,
+	IconWalletOutline24,
 	OutlineButton,
 	IconArrowRight16,
 	Button,
@@ -20,6 +21,7 @@ import { ethers } from 'ethers';
 import {
 	InputWrapper,
 	SelectTokenWrapper,
+	BadgesBase,
 	ForEstimatedMatchingAnimation,
 } from '../../../common/common.styled';
 import { TokenIconWithGIVBack } from '../../../TokenIcon/TokenIconWithGIVBack';
@@ -41,6 +43,7 @@ import StorageLabel from '@/lib/localStorage';
 import InlineToast, { EToastType } from '@/components/toasts/InlineToast';
 import { useAppSelector } from '@/features/hooks';
 import { useModalCallback } from '@/hooks/useModalCallback';
+import { useGeneralWallet } from '@/providers/generalWalletProvider';
 import EligibilityBadges from '@/components/views/donate/common/EligibilityBadges';
 import EstimatedMatchingToast from '../../EstimatedMatchingToast';
 
@@ -70,6 +73,7 @@ export const QRDonationCard: FC<QRDonationCardProps> = ({
 	const { modalCallback: signInThenDonate } = useModalCallback(() =>
 		setShowDonateModal(true),
 	);
+	const { isConnected } = useGeneralWallet();
 
 	const {
 		project,
@@ -90,7 +94,7 @@ export const QRDonationCard: FC<QRDonationCardProps> = ({
 		retrieveDraftDonation,
 	} = useQRCodeDonation(project);
 
-	const { addresses, id } = project;
+	const { addresses, id, isGivbackEligible } = project;
 	const draftDonationId = Number(router.query.draft_donation!);
 	const [amount, setAmount] = useState(0n);
 	const [usdAmount, setUsdAmount] = useState(0);
@@ -106,6 +110,21 @@ export const QRDonationCard: FC<QRDonationCardProps> = ({
 	const isOnEligibleNetworks = selectedQFRound?.eligibleNetworks?.includes(
 		config.STELLAR_NETWORK_NUMBER,
 	);
+	const isProjectGivbacksEligible = !!isGivbackEligible;
+	const isTokenGivbacksEligible = !!stellarToken?.isGivbackEligible;
+	const isGivbacksEligible =
+		isProjectGivbacksEligible && isTokenGivbacksEligible;
+
+	// Stellar QR donations are matched without connecting a wallet — QF matching
+	// eligibility is surfaced by EligibilityBadges and the estimated matching UI.
+	// The only action worth prompting here is signing in for GIVbacks, and only
+	// when both the project and the selected token are GIVbacks eligible.
+	const showConnectWallet = isGivbacksEligible;
+
+	const textToDisplayOnConnect = () =>
+		isGivbacksEligible
+			? 'label.sign_into_giveth_for_a_chance_to_win_givbacks'
+			: null;
 
 	const donationUsdValue =
 		(tokenPrice || 0) * Number(ethers.utils.formatEther(amount));
@@ -313,6 +332,18 @@ export const QRDonationCard: FC<QRDonationCardProps> = ({
 					})}
 				/>
 			)}
+			{!showQRCode &&
+				!isConnected &&
+				!showEstimatedMatching &&
+				showConnectWallet &&
+				textToDisplayOnConnect() && (
+					<ConnectWallet>
+						<IconWalletOutline24 color={neutralColors.gray[700]} />
+						{formatMessage({
+							id: textToDisplayOnConnect() || '',
+						})}
+					</ConnectWallet>
+				)}
 			{!showQRCode && (
 				<EligibilityBadges
 					amount={amount}
@@ -426,6 +457,10 @@ export const QRDonationCard: FC<QRDonationCardProps> = ({
 		</>
 	);
 };
+
+const ConnectWallet = styled(BadgesBase)`
+	margin-bottom: 5px;
+`;
 
 const CardHead = styled(Flex)`
 	align-items: center;

--- a/src/components/views/donate/OneTime/SelectTokenModal/QRCodeDonation/QRDonationCard.tsx
+++ b/src/components/views/donate/OneTime/SelectTokenModal/QRCodeDonation/QRDonationCard.tsx
@@ -5,6 +5,7 @@ import {
 	B,
 	P,
 	Flex,
+	brandColors,
 	neutralColors,
 	IconArrowLeft,
 	mediaQueries,
@@ -129,6 +130,13 @@ export const QRDonationCard: FC<QRDonationCardProps> = ({
 	// connected (mirrors handleNext, which signs in only when isEnabled). A
 	// wallet-less donor reads the prompt as guidance and uses the header Sign In.
 	const canSignIn = isEnabled && !isSignedIn;
+	const openSignIn = () => dispatch(setShowSignWithWallet(true));
+	const handleSignInKeyDown = (e: React.KeyboardEvent) => {
+		if (e.key === 'Enter' || e.key === ' ') {
+			e.preventDefault();
+			openSignIn();
+		}
+	};
 
 	const donationUsdValue =
 		(tokenPrice || 0) * Number(ethers.utils.formatEther(amount));
@@ -339,11 +347,10 @@ export const QRDonationCard: FC<QRDonationCardProps> = ({
 			{!showQRCode && showGivbacksSignInPrompt && (
 				<ConnectWallet
 					$clickable={canSignIn}
-					onClick={
-						canSignIn
-							? () => dispatch(setShowSignWithWallet(true))
-							: undefined
-					}
+					role={canSignIn ? 'button' : undefined}
+					tabIndex={canSignIn ? 0 : undefined}
+					onClick={canSignIn ? openSignIn : undefined}
+					onKeyDown={canSignIn ? handleSignInKeyDown : undefined}
 				>
 					<IconWalletOutline24 color={neutralColors.gray[700]} />
 					{formatMessage({
@@ -468,6 +475,11 @@ export const QRDonationCard: FC<QRDonationCardProps> = ({
 const ConnectWallet = styled(BadgesBase)<{ $clickable?: boolean }>`
 	margin-bottom: 5px;
 	cursor: ${({ $clickable }) => ($clickable ? 'pointer' : 'default')};
+
+	&:focus-visible {
+		outline: 2px solid ${brandColors.giv[500]};
+		outline-offset: 2px;
+	}
 `;
 
 const CardHead = styled(Flex)`

--- a/src/components/views/donate/OneTime/SelectTokenModal/QRCodeDonation/QRDonationCard.tsx
+++ b/src/components/views/donate/OneTime/SelectTokenModal/QRCodeDonation/QRDonationCard.tsx
@@ -41,9 +41,10 @@ import { useDonateData } from '@/context/donate.context';
 import { AmountInput } from '@/components/AmountInput/AmountInput';
 import StorageLabel from '@/lib/localStorage';
 import InlineToast, { EToastType } from '@/components/toasts/InlineToast';
-import { useAppSelector } from '@/features/hooks';
+import { useAppDispatch, useAppSelector } from '@/features/hooks';
+import { setShowSignWithWallet } from '@/features/modal/modal.slice';
+import { shouldShowGivbacksSignInPrompt } from '@/helpers/qf';
 import { useModalCallback } from '@/hooks/useModalCallback';
-import { useGeneralWallet } from '@/providers/generalWalletProvider';
 import EligibilityBadges from '@/components/views/donate/common/EligibilityBadges';
 import EstimatedMatchingToast from '../../EstimatedMatchingToast';
 
@@ -69,11 +70,11 @@ export const QRDonationCard: FC<QRDonationCardProps> = ({
 	const { formatMessage } = useIntl();
 	const router = useRouter();
 	const { isSignedIn, isEnabled } = useAppSelector(state => state.user);
+	const dispatch = useAppDispatch();
 	const [_showDonateModal, setShowDonateModal] = useState(false);
 	const { modalCallback: signInThenDonate } = useModalCallback(() =>
 		setShowDonateModal(true),
 	);
-	const { isConnected } = useGeneralWallet();
 
 	const {
 		project,
@@ -112,19 +113,22 @@ export const QRDonationCard: FC<QRDonationCardProps> = ({
 	);
 	const isProjectGivbacksEligible = !!isGivbackEligible;
 	const isTokenGivbacksEligible = !!stellarToken?.isGivbackEligible;
-	const isGivbacksEligible =
-		isProjectGivbacksEligible && isTokenGivbacksEligible;
 
-	// Stellar QR donations are matched without connecting a wallet — QF matching
-	// eligibility is surfaced by EligibilityBadges and the estimated matching UI.
-	// The only action worth prompting here is signing in for GIVbacks, and only
-	// when both the project and the selected token are GIVbacks eligible.
-	const showConnectWallet = isGivbacksEligible;
-
-	const textToDisplayOnConnect = () =>
-		isGivbacksEligible
-			? 'label.sign_into_giveth_for_a_chance_to_win_givbacks'
-			: null;
+	// Stellar QR donations are matched without connecting a wallet — matching is
+	// surfaced by EligibilityBadges / the estimated matching UI. The only action
+	// worth prompting here is signing in for GIVbacks. This shared predicate is
+	// the single source of truth: EligibilityBadges renders in the complementary
+	// case, so the prompt and the badges never overlap or leave a gap.
+	const showGivbacksSignInPrompt = shouldShowGivbacksSignInPrompt({
+		isProjectGivbacksEligible,
+		isTokenGivbacksEligible,
+		isSignedIn,
+		isEnabled,
+	});
+	// Signing in requires a wallet, so only offer the click-through when one is
+	// connected (mirrors handleNext, which signs in only when isEnabled). A
+	// wallet-less donor reads the prompt as guidance and uses the header Sign In.
+	const canSignIn = isEnabled && !isSignedIn;
 
 	const donationUsdValue =
 		(tokenPrice || 0) * Number(ethers.utils.formatEther(amount));
@@ -332,18 +336,21 @@ export const QRDonationCard: FC<QRDonationCardProps> = ({
 					})}
 				/>
 			)}
-			{!showQRCode &&
-				!isConnected &&
-				!showEstimatedMatching &&
-				showConnectWallet &&
-				textToDisplayOnConnect() && (
-					<ConnectWallet>
-						<IconWalletOutline24 color={neutralColors.gray[700]} />
-						{formatMessage({
-							id: textToDisplayOnConnect() || '',
-						})}
-					</ConnectWallet>
-				)}
+			{!showQRCode && showGivbacksSignInPrompt && (
+				<ConnectWallet
+					$clickable={canSignIn}
+					onClick={
+						canSignIn
+							? () => dispatch(setShowSignWithWallet(true))
+							: undefined
+					}
+				>
+					<IconWalletOutline24 color={neutralColors.gray[700]} />
+					{formatMessage({
+						id: 'label.sign_into_giveth_for_a_chance_to_win_givbacks',
+					})}
+				</ConnectWallet>
+			)}
 			{!showQRCode && (
 				<EligibilityBadges
 					amount={amount}
@@ -458,8 +465,9 @@ export const QRDonationCard: FC<QRDonationCardProps> = ({
 	);
 };
 
-const ConnectWallet = styled(BadgesBase)`
+const ConnectWallet = styled(BadgesBase)<{ $clickable?: boolean }>`
 	margin-bottom: 5px;
+	cursor: ${({ $clickable }) => ($clickable ? 'pointer' : 'default')};
 `;
 
 const CardHead = styled(Flex)`

--- a/src/components/views/donate/common/EligibilityBadges.tsx
+++ b/src/components/views/donate/common/EligibilityBadges.tsx
@@ -17,6 +17,8 @@ import {
 import { GIVBACKS_DONATION_QUALIFICATION_VALUE_USD } from '@/lib/constants/constants';
 import { useGeneralWallet } from '@/providers/generalWalletProvider';
 import { useDonateData } from '@/context/donate.context';
+import { useAppSelector } from '@/features/hooks';
+import { shouldShowGivbacksSignInPrompt } from '@/helpers/qf';
 import { IProjectAcceptedToken } from '@/apollo/types/gqlTypes';
 import config from '@/configuration';
 import { ChainType } from '@/types/config';
@@ -32,6 +34,7 @@ interface IEligibilityBadges {
 const EligibilityBadges: FC<IEligibilityBadges> = props => {
 	const { tokenPrice, amount, token, style } = props;
 	const { isConnected, chain } = useGeneralWallet();
+	const { isSignedIn, isEnabled } = useAppSelector(state => state.user);
 	const { selectedQFRound, project } = useDonateData();
 	const { formatMessage } = useIntl();
 	const { isGivbackEligible } = project || {};
@@ -66,9 +69,16 @@ const EligibilityBadges: FC<IEligibilityBadges> = props => {
 		isProjectGivbacksEligible &&
 		donationUsdValue >= GIVBACKS_DONATION_QUALIFICATION_VALUE_USD;
 
-	const isStellarOnlyRound =
-		selectedQFRound?.eligibleNetworks?.length === 1 &&
-		selectedQFRound?.eligibleNetworks[0] === config.STELLAR_NETWORK_NUMBER;
+	// The Stellar (QR) flow shows a "sign in for GIVbacks" prompt in this same
+	// case (see shouldShowGivbacksSignInPrompt / QRDonationCard). Render the
+	// badges only when that prompt does NOT — so for Stellar the two are mutually
+	// exclusive (no overlap, no gap) off a single shared predicate.
+	const showGivbacksSignInPrompt = shouldShowGivbacksSignInPrompt({
+		isProjectGivbacksEligible,
+		isTokenGivbacksEligible: !!isTokenGivbacksEligible,
+		isSignedIn,
+		isEnabled,
+	});
 
 	//  Define messageId BEFORE rendering to avoid issues
 	const messageId = isDonationMatched
@@ -83,8 +93,7 @@ const EligibilityBadges: FC<IEligibilityBadges> = props => {
 				? 'page.donate.unlocks_matching_funds'
 				: null; // Prevents invalid id values
 
-	return isConnected ||
-		(isStellar && isStellarOnlyRound && !isProjectGivbacksEligible) ? (
+	return (isStellar ? !showGivbacksSignInPrompt : isConnected) ? (
 		<EligibilityBadgeWrapper style={style}>
 			{/* Prevents QF Badge from rendering when !isOnQFEligibleNetworks && !activeStartedRound */}
 			{!(

--- a/src/components/views/donate/common/EligibilityBadges.tsx
+++ b/src/components/views/donate/common/EligibilityBadges.tsx
@@ -66,6 +66,10 @@ const EligibilityBadges: FC<IEligibilityBadges> = props => {
 		isProjectGivbacksEligible &&
 		donationUsdValue >= GIVBACKS_DONATION_QUALIFICATION_VALUE_USD;
 
+	const isStellarOnlyRound =
+		selectedQFRound?.eligibleNetworks?.length === 1 &&
+		selectedQFRound?.eligibleNetworks[0] === config.STELLAR_NETWORK_NUMBER;
+
 	//  Define messageId BEFORE rendering to avoid issues
 	const messageId = isDonationMatched
 		? 'page.donate.donations_will_be_matched'
@@ -79,9 +83,8 @@ const EligibilityBadges: FC<IEligibilityBadges> = props => {
 				? 'page.donate.unlocks_matching_funds'
 				: null; // Prevents invalid id values
 
-	// Stellar (QR) donations don't require a connected wallet, so always show
-	// the eligibility badges for the Stellar flow — same as a connected wallet.
-	return isConnected || isStellar ? (
+	return isConnected ||
+		(isStellar && isStellarOnlyRound && !isProjectGivbacksEligible) ? (
 		<EligibilityBadgeWrapper style={style}>
 			{/* Prevents QF Badge from rendering when !isOnQFEligibleNetworks && !activeStartedRound */}
 			{!(

--- a/src/helpers/qf.ts
+++ b/src/helpers/qf.ts
@@ -28,6 +28,34 @@ export const hasRoundStarted = (qfRound: IQFRound | null): boolean => {
 	return !!qfRound && new Date(qfRound.beginDate).getTime() < getNowUnixMS();
 };
 
+/**
+ * Single source of truth for the Stellar (QR) "sign in for GIVbacks" prompt.
+ *
+ * Stellar QR donations are matched without connecting a wallet, but GIVbacks
+ * attribution still requires the donor to be signed in (the donation is sent
+ * anonymously otherwise). The prompt should own the UI when GIVbacks is
+ * achievable purely by signing in — i.e. both the project and the token are
+ * GIVbacks eligible and the donor isn't fully signed in.
+ *
+ * Shared by QRDonationCard (renders the prompt when this is true) and
+ * EligibilityBadges (renders the badges only when this is false), so the two
+ * partition the disconnected-Stellar state with no overlap and no gap.
+ */
+export const shouldShowGivbacksSignInPrompt = ({
+	isProjectGivbacksEligible,
+	isTokenGivbacksEligible,
+	isSignedIn,
+	isEnabled,
+}: {
+	isProjectGivbacksEligible: boolean;
+	isTokenGivbacksEligible: boolean;
+	isSignedIn: boolean;
+	isEnabled: boolean;
+}): boolean =>
+	isProjectGivbacksEligible &&
+	isTokenGivbacksEligible &&
+	(!isEnabled || !isSignedIn);
+
 // TODO remove this once the ethereum security QF round is no longer active
 export const isProjectInActiveEthereumSecurityQFRound = async (
 	projectId: number | string,


### PR DESCRIPTION
## Description

Closes https://github.com/Giveth/giveth-dapps-v2/issues/5574

This PR updates the Stellar QR donation flow so logged-out donors can still see estimated matching information when their donation qualifies for an active QF round.

## Changes

- Show estimated matching for Stellar QR donations based on project, round, token price, and amount rather than wallet/sign-in state.
- Adjust Stellar donation eligibility badges so the logged-out QR flow can still surface QF eligibility where appropriate.
- Keep GIVbacks-specific messaging gated behind actual GIVbacks eligibility for both the project and selected Stellar token.
- Avoid prompting Stellar QR donors to connect a wallet for QF matching, since matching does not require an EVM/Solana wallet connection.

## Testing

- Not run locally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a wallet sign-in prompt for GIVbacks opportunities during QR-code donations when both the project and selected token are eligible and the user can sign in.

* **Improvements**
  * Adjusted eligibility badge display for Stellar token donations so badges are suppressed when the GIVbacks sign-in prompt is shown, based on wallet connection and user status.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->