### PR TITLE
Change scan code copy

### DIFF
--- a/lang/ct.json
+++ b/lang/ct.json
@@ -940,7 +940,7 @@
 	"label.save_changes": "Desa els canvis",
 	"label.save_on_gas_fees": "Estalvia en taxes de gas, canvia de xarxa.",
 	"label.say_hello_to": "Saluda a...",
-	"label.scan_to_donate": "Escaneja el codi QR o copia l’adreça per fer la transferència. Per obtenir millors resultats, utilitza una cartera nativa de Stellar; les donacions enviades directament des d’intercanvis centralitzats poden no ser detectades.",
+	"label.scan_to_donate": "Escaneja amb LOBSTR o Exodus, o copia l'adreça i el memo següents a la teva cartera. Si us plau, utilitza una cartera nativa de Stellar; és possible que les donacions enviades directament des d'intercanvis centralitzats no es detectin.",
 	"label.sdg_impact_fund": "Fons d'impacte SDG",
 	"label.search": "Cerca",
 	"label.search_for_a_project_or_a_cause": "Cerca un projecte o una causa a totes les categories",

--- a/lang/en.json
+++ b/lang/en.json
@@ -941,7 +941,7 @@
 	"label.save_changes": "Save Changes",
 	"label.save_on_gas_fees": "Save on gas fees, switch network.",
 	"label.say_hello_to": "Say Hello to...",
-	"label.scan_to_donate": "Scan the QR code or copy the address to make the transfer. For best results use a Stellar native wallet, donations directly from Centralized Exchanges may not be detected.",
+	"label.scan_to_donate": "Scan with LOBSTR or Exodus, or copy the address and memo below into your wallet. Please use a Stellar native wallet, donations directly from Centralized Exchanges may not be detected.",
 	"label.sdg_impact_fund": "SDG impact fund",
 	"label.search": "Search",
 	"label.search_for_a_project_or_a_cause": "Search for a project or a cause on all of the categories",

--- a/lang/es.json
+++ b/lang/es.json
@@ -940,7 +940,7 @@
 	"label.save_changes": "Guardar cambios",
 	"label.save_on_gas_fees": "Ahorra en tarifas de gas, cambia de red.",
 	"label.say_hello_to": "Dile hola a...",
-	"label.scan_to_donate": "Escanea el código QR o copia la dirección para realizar la transferencia. Para obtener mejores resultados, usa una billetera nativa de Stellar; las donaciones enviadas directamente desde exchanges centralizados pueden no ser detectadas.",
+	"label.scan_to_donate": "Escanea con LOBSTR o Exodus, o copia la dirección y el memo que aparecen a continuación en tu billetera. Por favor, utiliza una billetera nativa de Stellar; es posible que las donaciones enviadas directamente desde exchanges centralizados no se detecten.",
 	"label.sdg_impact_fund": "Fondo de impacto SDG",
 	"label.search": "Buscar",
 	"label.search_for_a_project_or_a_cause": "Busca un proyecto o una Causa en todas las categorias",


### PR DESCRIPTION
## Summary

Updates the Stellar donation instructions to make the wallet and transfer requirements clearer.

## Changes

- Recommends scanning the QR code with LOBSTR or Exodus.
- Instructs donors to copy both the Stellar address and memo when transferring manually.
- Retains the warning that donations from centralized exchanges may not be detected.
- Updates the copy in English, Spanish, and Catalan.

## Testing

- Verified the updated translations in all three locale files.
- No functional changes.

Related to #5581.