### PR TITLE
Stellar QF round hot fixes (#5609)

### DIFF
--- a/lang/ct.json
+++ b/lang/ct.json
@@ -2038,5 +2038,5 @@
 	"label.user.x_twitter_profile_placeholder": "El teu nom d'usuari a X/Twitter",
 	"label.user.telegram_profile": "Usuari de Telegram",
 	"label.user.telegram_profile_placeholder": "El teu nom d'usuari de Telegram",
-	"label.qf.quadratic_funding_is_live": "💜 El Finançament Quadràtic és en marxa. Fes que les teves donacions es multipliquin amb fons complementaris."
+	"label.qf.quadratic_funding_is_live": "💜 El Finançament Quadràtic és en marxa. Fes que les teves donacions s’amplifiquin amb un fons de compensació"
 }

--- a/lang/en.json
+++ b/lang/en.json
@@ -2038,5 +2038,5 @@
 	"label.user.x_twitter_profile_placeholder": "Your X/Twitter username",
 	"label.user.telegram_profile": "Telegram Handle",
 	"label.user.telegram_profile_placeholder": "Your Telegram username",
-	"label.qf.quadratic_funding_is_live": "💜 Quadratic Funding is Live. Get your donations amplified by a matching funds"
+	"label.qf.quadratic_funding_is_live": "💜 Quadratic Funding is live. Get your donations amplified by a matching pool"
 }

--- a/lang/es.json
+++ b/lang/es.json
@@ -2038,5 +2038,5 @@
 	"label.user.x_twitter_profile_placeholder": "Tu nombre de usuario en X/Twitter",
 	"label.user.telegram_profile": "Usuario de Telegram",
 	"label.user.telegram_profile_placeholder": "Tu nombre de usuario de Telegram",
-	"label.qf.quadratic_funding_is_live": "💜 La Financiación Cuadrática está activa. Haz que tus donaciones se amplifiquen con fondos de compensación."
+	"label.qf.quadratic_funding_is_live": "💜 La Financiación Cuadrática está activa. Haz que tus donaciones se amplifiquen con un fondo de igualación"
 }

--- a/src/apollo/gql/gqlQF.ts
+++ b/src/apollo/gql/gqlQF.ts
@@ -187,6 +187,11 @@ export const FETCH_PROJECT_QF_ROUNDS = gql`
 			isActive
 			allocatedFund
 			allocatedFundUSD
+			allocatedFundUSDPreferred
+			allocatedTokenSymbol
+			eligibleNetworks
+			maximumReward
+			minimumValidUsdValue
 			priority
 			beginDate
 			endDate

--- a/src/components/views/donate/DonationCard.tsx
+++ b/src/components/views/donate/DonationCard.tsx
@@ -6,7 +6,7 @@ import {
 	SublineBold,
 	brandColors,
 } from '@giveth/ui-design-system';
-import React, { FC, useState, useEffect } from 'react';
+import React, { FC, useState, useEffect, useRef } from 'react';
 import styled, { css } from 'styled-components';
 import { useIntl } from 'react-intl';
 import { useRouter } from 'next/router';
@@ -14,7 +14,6 @@ import { isAddress } from 'viem';
 import { captureException } from '@sentry/nextjs';
 import Image from 'next/image';
 
-import { useAccount } from 'wagmi';
 import { Shadow } from '@/components/styled-components/Shadow';
 import { RecurringDonationCard } from './Recurring/RecurringDonationCard';
 import OneTimeDonationCard from '@/components/views/donate/OneTime/OneTimeDonationCard';
@@ -31,6 +30,9 @@ import {
 } from '@/apollo/types/gqlTypes';
 import { DonationCardTabs } from '@/components/views/donate/DonationCardTabs';
 import { DonationCardQFRounds } from '@/components/views/donate/DonationCardQFRounds/DonationCardQFRounds';
+import { getActiveRound } from '@/helpers/qf';
+import { getDonationNetworkId } from '@/helpers/network';
+import { useGeneralWallet } from '@/providers/generalWalletProvider';
 
 export enum ETabs {
 	ONE_TIME = 'one-time',
@@ -47,7 +49,10 @@ export const DonationCard: FC<IDonationCardProps> = ({
 	setShowQRCode,
 }) => {
 	const router = useRouter();
-	const { chainId } = useAccount();
+	const { chain, walletChainType } = useGeneralWallet();
+	// Resolved for EVM and Solana wallets alike, so QF round selection and
+	// smart select work for both.
+	const chainId = getDonationNetworkId(chain, walletChainType);
 	const [tab, setTab] = useState(
 		router.query.tab === ETabs.RECURRING ? ETabs.RECURRING : ETabs.ONE_TIME,
 	);
@@ -106,6 +111,36 @@ export const DonationCard: FC<IDonationCardProps> = ({
 			{ shallow: true },
 		);
 	};
+
+	// Auto-switch to the Stellar (QR) flow when the active round is
+	// Stellar-only and the project accepts Stellar donations, so entry
+	// points without round data (e.g. project cards) still land on the
+	// right flow. Decided once, as soon as any rounds are available, so the
+	// QR flow's back button can opt out of it without being re-triggered.
+	const didEvaluateStellarAutoSwitch = useRef(false);
+	useEffect(() => {
+		if (
+			!router.isReady ||
+			didEvaluateStellarAutoSwitch.current ||
+			!project.qfRounds?.length
+		)
+			return;
+		didEvaluateStellarAutoSwitch.current = true;
+		const { activeStartedRound } = getActiveRound(project.qfRounds);
+		const isStellarOnlyRound =
+			activeStartedRound?.eligibleNetworks?.length === 1 &&
+			activeStartedRound?.eligibleNetworks[0] ===
+				config.STELLAR_NETWORK_NUMBER;
+		if (
+			!router.query.chain &&
+			router.query.tab !== ETabs.RECURRING &&
+			isStellarOnlyRound &&
+			hasStellarAddress
+		) {
+			handleQRDonation();
+		}
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [project.qfRounds, router.isReady]);
 
 	useEffect(() => {
 		client

--- a/src/components/views/donate/DonationCardQFRounds/DonationCardQFRounds.tsx
+++ b/src/components/views/donate/DonationCardQFRounds/DonationCardQFRounds.tsx
@@ -146,17 +146,26 @@ export const DonationCardQFRounds = ({
 				// Fallback to first active round
 				setSelectedQFRound(activeQFRounds[0] || EmptyRound);
 			}
-		} else if (
-			activeQFRounds.length > 0 &&
-			activeQFRounds[0].eligibleNetworks.includes(
-				isQRDonation ? config.STELLAR_NETWORK_NUMBER : chainId,
-			)
-		) {
-			// Fallback to first active round if no smart selection and the
-			// network is eligible (Stellar network for QR donations).
-			setSelectedQFRound(activeQFRounds[0]);
 		} else {
-			setSelectedQFRound(EmptyRound);
+			const effectiveChainId = isQRDonation
+				? config.STELLAR_NETWORK_NUMBER
+				: chainId;
+			// Fallback to the first active round eligible for the current
+			// network (Stellar network for QR donations).
+			const eligibleRound = activeQFRounds.find(round =>
+				round.eligibleNetworks.includes(effectiveChainId),
+			);
+			if (eligibleRound) {
+				setSelectedQFRound(eligibleRound);
+			} else if (!chainId && !isQRDonation) {
+				// Wallet not connected yet — default to the first active
+				// round instead of asking the user to pick; eligibility is
+				// re-evaluated on connect and EligibilityBadges warns if the
+				// network is not eligible for matching.
+				setSelectedQFRound(activeQFRounds[0] || EmptyRound);
+			} else {
+				setSelectedQFRound(EmptyRound);
+			}
 		}
 		setIsSmartSelect(!!smartSelectData);
 

--- a/src/components/views/donate/OneTime/DonateModal.tsx
+++ b/src/components/views/donate/OneTime/DonateModal.tsx
@@ -33,6 +33,7 @@ import { TxHashWithChainType, useDonateData } from '@/context/donate.context';
 import { useCreateEvmDonation } from '@/hooks/useCreateEvmDonation';
 import { useGeneralWallet } from '@/providers/generalWalletProvider';
 import { ChainType } from '@/types/config';
+import { getDonationNetworkId } from '@/helpers/network';
 import { IProject, IWalletAddress } from '@/apollo/types/types';
 import { useCreateSolanaDonation } from '@/hooks/useCreateSolanaDonation';
 import { useTokenPrice } from '@/hooks/useTokenPrice';
@@ -127,9 +128,12 @@ const DonateModal: FC<IDonateModalProps> = props => {
 
 	const tokenPrice = useTokenPrice(token);
 
-	const isOnEligibleNetworks = selectedQFRound?.eligibleNetworks?.includes(
-		(chain as Chain).id,
-	);
+	// EVM wallets have a numeric chain id; Solana wallets resolve to the
+	// configured Solana network id.
+	const donationNetworkId = getDonationNetworkId(chain, walletChainType);
+	const isOnEligibleNetworks =
+		!!donationNetworkId &&
+		selectedQFRound?.eligibleNetworks?.includes(donationNetworkId);
 	const includeInQF = selectedQFRound && isOnEligibleNetworks;
 	const chainvineReferred = getWithExpiry(StorageLabel.CHAINVINEREFERRED);
 	const { title, addresses } = project || {};
@@ -226,9 +230,12 @@ const DonateModal: FC<IDonateModalProps> = props => {
 			setFailedModalType,
 			symbol: token.symbol,
 			useDonationBox: isDonatingToGiveth,
-			qfRoundId: selectedQFRound?.id
-				? Number(selectedQFRound?.id)
-				: undefined,
+			// Only associate the donation with the round when the connected
+			// network is eligible for matching in it.
+			qfRoundId:
+				includeInQF && selectedQFRound?.id
+					? Number(selectedQFRound.id)
+					: undefined,
 		})
 			.then(({ isSaved, txHash: firstHash }) => {
 				if (!firstHash) {

--- a/src/components/views/donate/common/EligibilityBadges.tsx
+++ b/src/components/views/donate/common/EligibilityBadges.tsx
@@ -8,7 +8,7 @@ import {
 } from '@giveth/ui-design-system';
 import React, { CSSProperties, FC } from 'react';
 import { useIntl } from 'react-intl';
-import { Chain, formatUnits } from 'viem';
+import { formatUnits } from 'viem';
 import { useRouter } from 'next/router';
 import {
 	BadgesBase,
@@ -19,6 +19,7 @@ import { useGeneralWallet } from '@/providers/generalWalletProvider';
 import { useDonateData } from '@/context/donate.context';
 import { useAppSelector } from '@/features/hooks';
 import { shouldShowGivbacksSignInPrompt } from '@/helpers/qf';
+import { getDonationNetworkId } from '@/helpers/network';
 import { IProjectAcceptedToken } from '@/apollo/types/gqlTypes';
 import config from '@/configuration';
 import { ChainType } from '@/types/config';
@@ -33,7 +34,7 @@ interface IEligibilityBadges {
 
 const EligibilityBadges: FC<IEligibilityBadges> = props => {
 	const { tokenPrice, amount, token, style } = props;
-	const { isConnected, chain } = useGeneralWallet();
+	const { isConnected, chain, walletChainType } = useGeneralWallet();
 	const { isSignedIn, isEnabled } = useAppSelector(state => state.user);
 	const { selectedQFRound, project } = useDonateData();
 	const { formatMessage } = useIntl();
@@ -43,9 +44,7 @@ const EligibilityBadges: FC<IEligibilityBadges> = props => {
 	const isTokenGivbacksEligible = token?.isGivbackEligible;
 	const isProjectGivbacksEligible = !!isGivbackEligible;
 
-	const networkId = isStellar
-		? config.STELLAR_NETWORK_NUMBER
-		: (chain as Chain)?.id || config.SOLANA_CONFIG.networkId;
+	const networkId = getDonationNetworkId(chain, walletChainType, isStellar);
 
 	const isOnQFEligibleNetworks = selectedQFRound?.eligibleNetworks?.includes(
 		networkId || 0,
@@ -116,8 +115,9 @@ const EligibilityBadges: FC<IEligibilityBadges> = props => {
 							{
 								value: selectedQFRound?.minimumValidUsdValue,
 								network:
-									config.NETWORKS_CONFIG_WITH_ID[networkId]
-										?.name,
+									config.NETWORKS_CONFIG_WITH_ID[
+										networkId ?? 0
+									]?.name,
 							},
 						)}
 				</BadgesBase>

--- a/src/context/project.context.tsx
+++ b/src/context/project.context.tsx
@@ -34,6 +34,7 @@ import {
 import { IDonationsByProjectIdGQL } from '@/apollo/types/gqlTypes';
 import { FETCH_PROJECT_DONATIONS_COUNT } from '@/apollo/gql/gqlDonations';
 import { hasActiveRound } from '@/helpers/qf';
+import { fetchProjectQfRounds } from '@/helpers/projects';
 import { getGIVpowerBalanceByAddress } from '@/services/givpower';
 import { setShowSignWithWallet } from '@/features/modal/modal.slice';
 
@@ -118,6 +119,26 @@ export const ProjectProvider = ({
 	const isAdminEmailVerified = !!(isAdmin && user?.isEmailVerified);
 
 	const hasActiveQFRound = hasActiveRound(projectData?.qfRounds);
+
+	// The single project query skips the heavy qfRounds subquery, so attach
+	// the active rounds with the lighter projectQfRounds query whenever
+	// projectData is missing them (on mount and after client-side refetches).
+	useEffect(() => {
+		const projectId = projectData?.id;
+		if (!projectId || projectData?.qfRounds) return;
+		let ignore = false;
+		fetchProjectQfRounds(projectId, true).then(qfRounds => {
+			if (ignore) return;
+			setProjectData(prev =>
+				prev && prev.id === projectId && !prev.qfRounds
+					? { ...prev, qfRounds }
+					: prev,
+			);
+		});
+		return () => {
+			ignore = true;
+		};
+	}, [projectData?.id, projectData?.qfRounds]);
 
 	const fetchProjectBySlug = useCallback(async () => {
 		setIsLoading(true);

--- a/src/helpers/network.ts
+++ b/src/helpers/network.ts
@@ -1,6 +1,27 @@
 import { getChainId, switchChain } from '@wagmi/core';
+import { Chain } from 'viem';
+import { WalletAdapterNetwork } from '@solana/wallet-adapter-base';
 import { wagmiConfig } from '@/wagmiConfigs';
 import config from '@/configuration';
+import { ChainType } from '@/types/config';
+
+/**
+ * Resolve the network id a donation flow should treat as "current".
+ * EVM wallets have a numeric chain id, Solana wallets map to the configured
+ * Solana network id, and the Stellar (QR) flow is not tied to a wallet at
+ * all. Single source of truth for QF round eligibility checks — keep
+ * DonateModal, EligibilityBadges and the QF round selection in sync.
+ */
+export const getDonationNetworkId = (
+	chain: Chain | WalletAdapterNetwork | undefined,
+	walletChainType: ChainType | null,
+	isStellar: boolean = false,
+): number | undefined => {
+	if (isStellar) return config.STELLAR_NETWORK_NUMBER;
+	if (walletChainType === ChainType.SOLANA)
+		return config.SOLANA_CONFIG.networkId;
+	return (chain as Chain)?.id;
+};
 
 export const ensureCorrectNetwork = async (targetChainId: number) => {
 	try {

--- a/src/helpers/projects.ts
+++ b/src/helpers/projects.ts
@@ -149,10 +149,12 @@ export const fetchProjectQfRounds = async (
 	activeOnly: boolean = true,
 	sortBy: string = '',
 ) => {
+	const numericProjectId = parseInt(projectId);
+	if (Number.isNaN(numericProjectId)) return [];
 	try {
 		const { data } = await client.query({
 			query: FETCH_PROJECT_QF_ROUNDS,
-			variables: { projectId: parseInt(projectId), activeOnly, sortBy },
+			variables: { projectId: numericProjectId, activeOnly, sortBy },
 			fetchPolicy: 'no-cache',
 			context: {
 				skipAuth: true,


### PR DESCRIPTION
## Summary

Fixes Stellar QF round donation flows and improves network eligibility handling across EVM, Solana, and Stellar.

## Changes

- Automatically opens the Stellar QR flow for Stellar-only rounds.
- Fetches active QF rounds when missing from project details.
- Selects the first QF round eligible for the active donation network.
- Centralizes donation network resolution for EVM, Solana, and Stellar.
- Associates donations with a QF round only when the network is eligible.
- Adds missing fields to the project QF rounds query.
- Improves QF banner translations.
- Safely handles invalid project IDs when fetching rounds.

## Test scenarios

- [ ] Donate to a Stellar project in a Stellar-only QF round.
- [ ] Enter the donation flow from project pages and project cards.
- [ ] Verify eligible-round selection with EVM and Solana wallets.
- [ ] Verify disconnected wallets default to an active round.
- [ ] Verify ineligible-network donations are not associated with the QF round.
- [ ] Verify returning from the Stellar QR flow does not reopen it automatically.

Closes #5609

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved donation flow support across EVM, Solana, and Stellar networks.
  - Automatically switches to Stellar QR donations when a project’s active funding round supports only Stellar.
  - More accurately selects eligible quadratic funding rounds and applies matching eligibility based on the selected network.
  - Project funding-round details now load more reliably when initially unavailable.

- **Documentation**
  - Updated English, Catalan, and Spanish quadratic funding messages for clearer wording.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->