### PR TITLE
Restore QF section on project page: Stellar donate routing & eligible networks

### DIFF
--- a/src/components/views/cause/CauseIndex.tsx
+++ b/src/components/views/cause/CauseIndex.tsx
@@ -26,7 +26,7 @@ import ProjectCategoriesBadges from '@/components/views/project/ProjectCategorie
 import ProjectGIVbackToast from '@/components/views/project/ProjectGIVbackToast';
 import useMediaQuery from '@/hooks/useMediaQuery';
 import { device } from '@/lib/constants/constants';
-import { DonateSection } from '@/components/views/project/projectActionCard/DonationSection';
+import { DonateSectionSwitcher } from '@/components/views/project/projectActionCard/DonationSection';
 import { ProjectStats } from '@/components/views/project/projectActionCard/ProjectStats';
 import { AdminActions } from '@/components/views/project/projectActionCard/AdminActions';
 import ProjectOwnerBanner from '@/components/views/project/ProjectOwnerBanner';
@@ -160,7 +160,7 @@ const CauseIndex: FC<ICauseBySlug> = () => {
 						)}
 						{isMobile && (
 							<MobileContainer $hasActiveRound={hasActiveQFRound}>
-								<DonateSection projectData={projectData} />
+								<DonateSectionSwitcher />
 							</MobileContainer>
 						)}
 						<ProjectGIVbackToast />

--- a/src/components/views/project/ProjectIndex.tsx
+++ b/src/components/views/project/ProjectIndex.tsx
@@ -36,7 +36,7 @@ import ProjectCategoriesBadges from './ProjectCategoriesBadges';
 import ProjectGIVbackToast from '@/components/views/project/ProjectGIVbackToast';
 import useMediaQuery from '@/hooks/useMediaQuery';
 import { device, mediaQueries } from '@/lib/constants/constants';
-import { DonateSection } from './projectActionCard/DonationSection';
+import { DonateSectionSwitcher } from './projectActionCard/DonationSection';
 import { ProjectStats } from './projectActionCard/ProjectStats';
 import { AdminActions } from './projectActionCard/AdminActions';
 import ProjectOwnerBanner from './ProjectOwnerBanner';
@@ -232,7 +232,7 @@ const ProjectIndex: FC<IProjectBySlug> = () => {
 						)}
 						{isMobile && (
 							<MobileContainer $hasActiveRound={hasActiveQFRound}>
-								<DonateSection projectData={projectData} />
+								<DonateSectionSwitcher />
 							</MobileContainer>
 						)}
 						<ProjectGIVbackToast />

--- a/src/components/views/project/projectActionCard/DonationSection.tsx
+++ b/src/components/views/project/projectActionCard/DonationSection.tsx
@@ -19,13 +19,27 @@ import { device } from '@/lib/constants/constants';
 import { formatDonation } from '@/helpers/number';
 import { IProject } from '@/apollo/types/types';
 import { useDonateData } from '@/context/donate.context';
+import { useProjectContext } from '@/context/project.context';
 import { ORGANIZATION } from '@/lib/constants/organizations';
 import links from '@/lib/constants/links';
 import { EProjectType } from '@/apollo/types/gqlEnums';
+import QFSection from './QFSection';
 
 interface IDonateSectionProps {
 	projectData?: IProject;
 }
+
+// Single source of truth for picking the donate section on project and
+// cause pages: the QF variant (estimated matching + eligible networks)
+// during an active started round, the regular one otherwise.
+export const DonateSectionSwitcher = () => {
+	const { hasActiveQFRound, projectData } = useProjectContext();
+	return hasActiveQFRound ? (
+		<QFSection projectData={projectData} />
+	) : (
+		<DonateSection projectData={projectData} />
+	);
+};
 
 export const DonateSection: FC<IDonateSectionProps> = ({ projectData }) => {
 	const { formatMessage, locale } = useIntl();

--- a/src/components/views/project/projectActionCard/ProjectActionCard.tsx
+++ b/src/components/views/project/projectActionCard/ProjectActionCard.tsx
@@ -6,7 +6,7 @@ import { useProjectContext } from '@/context/project.context';
 import useMediaQuery from '@/hooks/useMediaQuery';
 import { device } from '@/lib/constants/constants';
 import MobileDonateFooter from './MobileDonateFooter';
-import { DonateSection } from './DonationSection';
+import { DonateSectionSwitcher } from './DonationSection';
 import { ProjectPublicActions } from './ProjectPublicActions';
 
 export const ProjectActionCard = () => {
@@ -31,14 +31,13 @@ export const ProjectActionCard = () => {
 };
 
 const ProjectActionInnerCard = () => {
-	const { isAdmin, hasActiveQFRound, isDraft, projectData } =
-		useProjectContext();
+	const { isAdmin, isDraft } = useProjectContext();
 	const isMobile = !useMediaQuery(device.tablet);
 
 	return (
 		<>
 			{isAdmin && !isDraft && <AdminActions />}
-			<DonateSection projectData={projectData} />
+			<DonateSectionSwitcher />
 			{!isMobile && !isAdmin && <ProjectPublicActions />}
 			{isAdmin && <ProjectStats />}
 		</>


### PR DESCRIPTION
## Summary

Restores the QF-specific donation section on project and cause detail pages during an active, started QF round.

This ensures Stellar-only rounds:

- Route the Donate button directly to the Stellar QR donation flow.
- Display eligible networks for matching.
- Avoid the regular donation flow and unsupported-network errors.

Outside an active, started QF round, the regular donation section remains unchanged.

## Changes

- Added a shared `DonateSectionSwitcher` driven by `ProjectContext`.
- Rendered `QFSection` when the project has an active, started QF round.
- Retained the standard `DonateSection` as the fallback.
- Applied the shared behavior across:
  - Project pages
  - Cause pages
  - Desktop action cards
  - Mobile donation sections
- Removed duplicated donation-section selection logic.

## How to test

- [ ] Open a project participating in an active, started Stellar-only QF round.
- [ ] Confirm the QF section and eligible matching networks are displayed.
- [ ] Confirm Donate routes directly to the Stellar QR flow on desktop.
- [ ] Confirm the same behavior on mobile.
- [ ] Verify a project with no active round displays the regular donation section.
- [ ] Verify an upcoming round that has not started does not activate the QF section.
- [ ] Verify project and cause pages continue rendering correctly.

Issue: https://github.com/Giveth/giveth-dapps-v2/issues/5610

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Donation sections now automatically display the appropriate option based on whether an active funding round is available.
  * Updated mobile donation views to use the new automatic selection behavior.
* **Bug Fixes**
  * Improved consistency between project and cause donation experiences across mobile and action card layouts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->