### PR TITLE
Stellar-only QF round: route round selector to Stellar donate flow instead of switch-network modal

### DIFF
--- a/src/components/modals/SwitchNetworkQFRound.tsx
+++ b/src/components/modals/SwitchNetworkQFRound.tsx
@@ -37,6 +37,7 @@ interface ISwitchNetworkModal extends IModal {
 	clickedRound?: IQFRound | null;
 	setChoosedModalRound?: (round: IQFRound | undefined) => void;
 	onRoundSelect?: (round: IQFRound) => void;
+	onStellarDonation?: () => void;
 }
 
 const SwitchNetworkQFRound: FC<ISwitchNetworkModal> = ({
@@ -47,6 +48,7 @@ const SwitchNetworkQFRound: FC<ISwitchNetworkModal> = ({
 	clickedRound,
 	setChoosedModalRound,
 	onRoundSelect,
+	onStellarDonation,
 }) => {
 	const { isAnimating, closeModal } = useModalAnimation(setShowModal);
 	const { switchChain } = useSwitchChain();
@@ -61,6 +63,8 @@ const SwitchNetworkQFRound: FC<ISwitchNetworkModal> = ({
 	const chainId = (chain as Chain)?.id;
 	const theme = useAppSelector(state => state.general.theme);
 
+	// Callers only include a Stellar entry when the Stellar (QR) donate
+	// flow can be opened (see getSwitchableNetworks in DonationCardQFRounds)
 	const networks =
 		customNetworks?.map(network => {
 			return {
@@ -70,6 +74,18 @@ const SwitchNetworkQFRound: FC<ISwitchNetworkModal> = ({
 		}) || defaultNetworks;
 
 	const handleNetworkItemClick = (networkId: number, chainType: string) => {
+		// Stellar donations happen via QR code — no wallet connection or
+		// network switch involved. Open the Stellar donate flow directly.
+		if (chainType === ChainType.STELLAR) {
+			if (clickedRound) {
+				setChoosedModalRound?.(clickedRound);
+				onRoundSelect?.(clickedRound);
+			}
+			onStellarDonation?.();
+			closeModal();
+			closeOtherModal?.();
+			return;
+		}
 		if (walletChainType === ChainType.SOLANA) {
 			setPendingNetworkId(networkId);
 			handleSingOutAndSignInWithEVM();

--- a/src/components/project-card/ProjectCard.tsx
+++ b/src/components/project-card/ProjectCard.tsx
@@ -31,13 +31,17 @@ import {
 import { ORGANIZATION } from '@/lib/constants/organizations';
 import { mediaQueries } from '@/lib/constants/constants';
 import { ProjectCardUserName } from './ProjectCardUserName';
-import { getActiveRound, hasRoundStarted } from '@/helpers/qf';
+import {
+	getActiveRound,
+	hasRoundStarted,
+	hasStellarAddress,
+	isStellarOnlyRound,
+} from '@/helpers/qf';
 import { RoundNotStartedModal } from './RoundNotStartedModal';
 import { FETCH_RECURRING_DONATIONS_BY_DATE } from '@/apollo/gql/gqlProjects';
 import { client } from '@/apollo/apolloClient';
 import { ProjectCardTotalRaised } from './ProjectCardTotalRaised';
 import { ProjectCardTotalRaisedQF } from './ProjectCardTotalRaisedQF';
-import config from '@/configuration';
 import { EProjectType } from '@/apollo/types/gqlEnums';
 import { ProjectCardCauseTotalRaised } from './ProjectCardCauseTotalRaised';
 import {
@@ -143,16 +147,17 @@ const ProjectCard = (props: IProjectCard) => {
 	const isOnlyStellar =
 		addresses?.length === 1 && addresses[0]?.chainType === 'STELLAR';
 
-	const isStellarOnlyRound =
-		activeQFRound?.eligibleNetworks?.length === 1 &&
-		activeQFRound?.eligibleNetworks[0] === config.STELLAR_NETWORK_NUMBER;
+	// During an active, started Stellar-only round, Donate goes straight to
+	// the Stellar (QR) flow — provided the project can receive on Stellar.
+	const routeToStellarDonate =
+		isStellarOnlyRound(checkActiveRound) && hasStellarAddress(addresses);
 
 	const projectLink =
 		projectType === EProjectType.CAUSE
 			? slugToCauseView(slug)
 			: slugToProjectView(slug);
 
-	const donateLink = isStellarOnlyRound
+	const donateLink = routeToStellarDonate
 		? slugToProjectDonateStellar(slug)
 		: projectType === EProjectType.CAUSE
 			? slugToCauseDonate(slug) +

--- a/src/components/views/donate/DonationCard.tsx
+++ b/src/components/views/donate/DonationCard.tsx
@@ -6,7 +6,7 @@ import {
 	SublineBold,
 	brandColors,
 } from '@giveth/ui-design-system';
-import React, { FC, useState, useEffect, useRef } from 'react';
+import React, { FC, useState, useEffect, useRef, useCallback } from 'react';
 import styled, { css } from 'styled-components';
 import { useIntl } from 'react-intl';
 import { useRouter } from 'next/router';
@@ -30,7 +30,11 @@ import {
 } from '@/apollo/types/gqlTypes';
 import { DonationCardTabs } from '@/components/views/donate/DonationCardTabs';
 import { DonationCardQFRounds } from '@/components/views/donate/DonationCardQFRounds/DonationCardQFRounds';
-import { getActiveRound } from '@/helpers/qf';
+import {
+	getActiveRound,
+	hasStellarAddress,
+	isStellarOnlyRound,
+} from '@/helpers/qf';
 import { getDonationNetworkId } from '@/helpers/network';
 import { useGeneralWallet } from '@/providers/generalWalletProvider';
 
@@ -94,11 +98,12 @@ export const DonationCard: FC<IDonationCardProps> = ({
 
 	const disableRecurringDonations = organization?.disableRecurringDonations;
 
-	const hasStellarAddress = addresses?.some(
-		address => address.chainType === ChainType.STELLAR,
-	);
+	const projectHasStellarAddress = hasStellarAddress(addresses);
 
-	const handleQRDonation = () => {
+	// Memoized: passed down as onStellarDonation, where a fresh identity
+	// each render would re-trigger the round-selection effect and revert
+	// manual round picks in the regular flow.
+	const handleQRDonation = useCallback(() => {
 		setIsQRDonation(true);
 		router.push(
 			{
@@ -110,7 +115,7 @@ export const DonationCard: FC<IDonationCardProps> = ({
 			undefined,
 			{ shallow: true },
 		);
-	};
+	}, [router]);
 
 	// Auto-switch to the Stellar (QR) flow when the active round is
 	// Stellar-only and the project accepts Stellar donations, so entry
@@ -127,15 +132,11 @@ export const DonationCard: FC<IDonationCardProps> = ({
 			return;
 		didEvaluateStellarAutoSwitch.current = true;
 		const { activeStartedRound } = getActiveRound(project.qfRounds);
-		const isStellarOnlyRound =
-			activeStartedRound?.eligibleNetworks?.length === 1 &&
-			activeStartedRound?.eligibleNetworks[0] ===
-				config.STELLAR_NETWORK_NUMBER;
 		if (
 			!router.query.chain &&
 			router.query.tab !== ETabs.RECURRING &&
-			isStellarOnlyRound &&
-			hasStellarAddress
+			isStellarOnlyRound(activeStartedRound) &&
+			projectHasStellarAddress
 		) {
 			handleQRDonation();
 		}
@@ -199,6 +200,7 @@ export const DonationCard: FC<IDonationCardProps> = ({
 						choosedModalRound={choosedModalRound}
 						setChoosedModalRound={setChoosedModalRound}
 						isQRDonation={isQRDonation}
+						onStellarDonation={handleQRDonation}
 					/>
 				)}
 				{!isQRDonation ? (
@@ -220,7 +222,7 @@ export const DonationCard: FC<IDonationCardProps> = ({
 								<RecurringDonationCard />
 							)}
 						</TabWrapper>
-						{hasStellarAddress && (
+						{projectHasStellarAddress && (
 							<QRToastLink onClick={handleQRDonation}>
 								<Image
 									src='/images/logo/stellar.svg'

--- a/src/components/views/donate/DonationCardQFRounds/DonationCardQFRounds.tsx
+++ b/src/components/views/donate/DonationCardQFRounds/DonationCardQFRounds.tsx
@@ -107,20 +107,21 @@ export const DonationCardQFRounds = ({
 
 	// Networks the switch-network modal can act on for a round: eligible
 	// for the round, accepted by the project, and — for Stellar — only
-	// when the caller can open the Stellar (QR) flow.
+	// when the caller can open the Stellar (QR) flow. Stellar addresses are
+	// identified by chainType (their networkId is not guaranteed); other
+	// networks match by networkId.
 	const getSwitchableNetworks = useCallback(
 		(round: IQFRound) => {
 			const projectAcceptedChains = project.addresses?.map(
 				address => address.networkId,
 			);
-			return round.eligibleNetworks.filter(
-				network =>
-					projectAcceptedChains?.includes(network) &&
-					(network !== config.STELLAR_NETWORK_NUMBER ||
-						!!onStellarDonation),
+			return round.eligibleNetworks.filter(network =>
+				network === config.STELLAR_NETWORK_NUMBER
+					? projectHasStellarAddress && !!onStellarDonation
+					: projectAcceptedChains?.includes(network),
 			);
 		},
-		[project.addresses, onStellarDonation],
+		[project.addresses, projectHasStellarAddress, onStellarDonation],
 	);
 
 	// Rounds this flow has a route to donate to — the single source of

--- a/src/components/views/donate/DonationCardQFRounds/DonationCardQFRounds.tsx
+++ b/src/components/views/donate/DonationCardQFRounds/DonationCardQFRounds.tsx
@@ -1,4 +1,10 @@
-import React, { useEffect, useMemo, useRef, useState } from 'react';
+import React, {
+	useCallback,
+	useEffect,
+	useMemo,
+	useRef,
+	useState,
+} from 'react';
 import styled from 'styled-components';
 import {
 	B,
@@ -19,6 +25,7 @@ import {
 	useFetchQFRoundSmartSelect,
 } from '../../donateCause/helpers';
 import config from '@/configuration';
+import { hasStellarAddress, isStellarOnlyRound } from '@/helpers/qf';
 
 // Add text truncation utility function
 const truncateText = (text: string, maxLength: number = 50) => {
@@ -57,6 +64,7 @@ export const DonationCardQFRounds = ({
 	choosedModalRound,
 	setChoosedModalRound,
 	isQRDonation,
+	onStellarDonation,
 }: {
 	project: IProject;
 	chainId: number;
@@ -65,6 +73,7 @@ export const DonationCardQFRounds = ({
 	choosedModalRound: IQFRound | undefined;
 	setChoosedModalRound: (round: IQFRound | undefined) => void;
 	isQRDonation?: boolean;
+	onStellarDonation?: () => void;
 }) => {
 	const didRunRef = useRef(false);
 	const { formatMessage } = useIntl();
@@ -82,6 +91,70 @@ export const DonationCardQFRounds = ({
 		return rounds;
 	}, [project.qfRounds, isQRDonation]);
 
+	const projectHasStellarAddress = hasStellarAddress(project.addresses);
+
+	// Stellar is not a wallet network: a Stellar-only round must open the
+	// Stellar (QR) donate flow directly. Only flows that can open it
+	// qualify: the QR flow itself, or a caller providing onStellarDonation
+	// (the cause flow provides neither).
+	const opensStellarFlow = useCallback(
+		(round: IQFRound) =>
+			isStellarOnlyRound(round) &&
+			projectHasStellarAddress &&
+			(!!isQRDonation || !!onStellarDonation),
+		[projectHasStellarAddress, isQRDonation, onStellarDonation],
+	);
+
+	// Networks the switch-network modal can act on for a round: eligible
+	// for the round, accepted by the project, and — for Stellar — only
+	// when the caller can open the Stellar (QR) flow.
+	const getSwitchableNetworks = useCallback(
+		(round: IQFRound) => {
+			const projectAcceptedChains = project.addresses?.map(
+				address => address.networkId,
+			);
+			return round.eligibleNetworks.filter(
+				network =>
+					projectAcceptedChains?.includes(network) &&
+					(network !== config.STELLAR_NETWORK_NUMBER ||
+						!!onStellarDonation),
+			);
+		},
+		[project.addresses, onStellarDonation],
+	);
+
+	// Rounds this flow has a route to donate to — the single source of
+	// truth for the default-round selection and the picker modal alike.
+	const selectableRounds = useMemo(
+		() =>
+			activeQFRounds.filter(
+				round =>
+					opensStellarFlow(round) ||
+					(isQRDonation &&
+						round.eligibleNetworks.includes(
+							config.STELLAR_NETWORK_NUMBER,
+						)) ||
+					round.eligibleNetworks.includes(chainId) ||
+					getSwitchableNetworks(round).length > 0,
+			),
+		[
+			activeQFRounds,
+			opensStellarFlow,
+			getSwitchableNetworks,
+			isQRDonation,
+			chainId,
+		],
+	);
+
+	// Default-selection candidates: selectable rounds the regular one-time
+	// flow can donate to with a connected wallet — Stellar-only rounds are
+	// excluded (they are donated to via the Stellar QR flow, which the
+	// round selector routes to on pick).
+	const walletEligibleRounds = useMemo(
+		() => selectableRounds.filter(round => !isStellarOnlyRound(round)),
+		[selectableRounds],
+	);
+
 	const [isSmartSelect, setIsSmartSelect] = useState(false);
 	const [showQFRoundModal, setShowQFRoundModal] = useState(false);
 
@@ -94,7 +167,7 @@ export const DonationCardQFRounds = ({
 			isQRDonation ? config.STELLAR_NETWORK_NUMBER : chainId,
 			!!project.id &&
 				(isQRDonation || !!chainId) &&
-				activeQFRounds.length > 0,
+				selectableRounds.length > 0,
 		);
 
 	const handleRoundSelect = (round: IQFRound) => {
@@ -107,6 +180,10 @@ export const DonationCardQFRounds = ({
 	const { data: web3ModalData } = useWeb3ModalEvents();
 	const modalOpen = useRef(false);
 	const initialChainId = useRef<number | null>(null);
+	// Last chainId the default-round effect observed, used to detect an
+	// actual network change (including in-wallet switches that bypass the
+	// web3modal) so a stale pin can be released.
+	const prevChainId = useRef(chainId);
 
 	useEffect(() => {
 		if (web3ModalData?.event === 'MODAL_OPEN' && !modalOpen.current) {
@@ -128,6 +205,59 @@ export const DonationCardQFRounds = ({
 
 	// Set up default QF round
 	useEffect(() => {
+		// Detect an actual network change since the last run (an in-wallet
+		// switch updates chainId without firing a web3modal event).
+		const chainChanged = prevChainId.current !== chainId;
+		prevChainId.current = chainId;
+
+		// Stellar (QR) flow: the round is dictated by the flow itself —
+		// selectableRounds is already reduced to Stellar-eligible rounds, so
+		// select one immediately instead of waiting for smart select or
+		// depending on the connected wallet's chain. A round the user picked
+		// in the modal wins; the smart-select result upgrades the default.
+		if (isQRDonation) {
+			const pinnedRound =
+				choosedModalRound &&
+				selectableRounds.find(
+					round => round.id === choosedModalRound.id,
+				);
+			const smartRound = smartSelectData?.qfRoundId
+				? selectableRounds.find(
+						round =>
+							round.id === smartSelectData.qfRoundId.toString(),
+					)
+				: undefined;
+			setSelectedQFRound(
+				pinnedRound || smartRound || selectableRounds[0] || EmptyRound,
+			);
+			setIsSmartSelect(!pinnedRound && !!smartRound);
+			return;
+		}
+
+		// When the donor backs out of the Stellar (QR) flow with a pinned
+		// Stellar-only round, drop the pin so eligibility is recomputed for
+		// the connected chain and donating on the project's other networks
+		// works.
+		if (isStellarOnlyRound(choosedModalRound)) {
+			setChoosedModalRound(undefined);
+			return;
+		}
+
+		// The wallet switched to a network the pinned round is not eligible
+		// for (e.g. an in-wallet network change that bypasses the web3modal):
+		// drop the pin so an eligible round is recomputed for the new chain.
+		// Only on an actual change — the switch-network modal pins a round for
+		// the chain it is switching *to*, before chainId has caught up.
+		if (
+			choosedModalRound &&
+			chainChanged &&
+			!!chainId &&
+			!choosedModalRound.eligibleNetworks.includes(chainId)
+		) {
+			setChoosedModalRound(undefined);
+			return;
+		}
+
 		// This option is seelcted by user inside modal and after he changed network we should use this option
 		if (choosedModalRound) {
 			setSelectedQFRound(choosedModalRound);
@@ -136,48 +266,46 @@ export const DonationCardQFRounds = ({
 
 		// This option is fired when user get on the page or change network inside wallet
 		if (smartSelectData && smartSelectData.qfRoundId) {
-			// Find the matching QF round from active rounds
-			const matchingRound = activeQFRounds.find(
+			// Find the matching QF round among the wallet-donatable rounds
+			const matchingRound = walletEligibleRounds.find(
 				round => round.id === smartSelectData.qfRoundId.toString(),
 			);
 			if (matchingRound) {
 				setSelectedQFRound(matchingRound);
+				setIsSmartSelect(true);
 			} else {
-				// Fallback to first active round
-				setSelectedQFRound(activeQFRounds[0] || EmptyRound);
+				setSelectedQFRound(walletEligibleRounds[0] || EmptyRound);
+				setIsSmartSelect(false);
 			}
 		} else {
-			const effectiveChainId = isQRDonation
-				? config.STELLAR_NETWORK_NUMBER
-				: chainId;
-			// Fallback to the first active round eligible for the current
-			// network (Stellar network for QR donations).
-			const eligibleRound = activeQFRounds.find(round =>
-				round.eligibleNetworks.includes(effectiveChainId),
+			// Fallback to the first round eligible for the connected network
+			const eligibleRound = walletEligibleRounds.find(round =>
+				round.eligibleNetworks.includes(chainId),
 			);
 			if (eligibleRound) {
 				setSelectedQFRound(eligibleRound);
-			} else if (!chainId && !isQRDonation) {
-				// Wallet not connected yet — default to the first active
-				// round instead of asking the user to pick; eligibility is
-				// re-evaluated on connect and EligibilityBadges warns if the
-				// network is not eligible for matching.
-				setSelectedQFRound(activeQFRounds[0] || EmptyRound);
+			} else if (!chainId) {
+				// Wallet not connected yet — default to the first
+				// wallet-donatable round instead of asking the user to pick;
+				// eligibility is re-evaluated on connect and
+				// EligibilityBadges warns if the network is not eligible for
+				// matching.
+				setSelectedQFRound(walletEligibleRounds[0] || EmptyRound);
 			} else {
 				setSelectedQFRound(EmptyRound);
 			}
+			setIsSmartSelect(false);
 		}
-		setIsSmartSelect(!!smartSelectData);
 
 		// Run only once to set selected round from URL
 		if (
 			!didRunRef.current &&
 			router.query.roundId &&
 			chainId !== 0 &&
-			activeQFRounds.length > 1 &&
+			selectableRounds.length > 1 &&
 			!isFetchingSmartSelect
 		) {
-			const matchedRound = activeQFRounds.find(
+			const matchedRound = selectableRounds.find(
 				round => round.id === router.query.roundId,
 			);
 			if (matchedRound?.eligibleNetworks.includes(chainId)) {
@@ -188,7 +316,8 @@ export const DonationCardQFRounds = ({
 			didRunRef.current = true;
 		}
 	}, [
-		activeQFRounds,
+		selectableRounds,
+		walletEligibleRounds,
 		smartSelectData,
 		chainId,
 		setSelectedQFRound,
@@ -196,19 +325,10 @@ export const DonationCardQFRounds = ({
 		isQRDonation,
 	]);
 
-	// Return nothing if there are no QF rounds
-	if (!activeQFRounds || activeQFRounds.length === 0) {
+	// Nothing this flow has a route to donate to — no selector (e.g. the
+	// cause flow when the only active round is Stellar-only)
+	if (selectableRounds.length === 0) {
 		return null;
-	}
-
-	// If it is stellar donation and there is no active round with stellar, return null
-	if (isQRDonation && activeQFRounds.length > 0) {
-		const stellarRound = activeQFRounds.find(round =>
-			round.eligibleNetworks.includes(config.STELLAR_NETWORK_NUMBER),
-		);
-		if (!stellarRound) {
-			return null;
-		}
 	}
 
 	return (
@@ -245,7 +365,7 @@ export const DonationCardQFRounds = ({
 			</Container>
 			{showQFRoundModal && (
 				<QFRoundsModal
-					QFRounds={activeQFRounds}
+					QFRounds={selectableRounds}
 					setShowModal={setShowQFRoundModal}
 					project={project}
 					selectedRound={selectedQFRound}
@@ -253,6 +373,9 @@ export const DonationCardQFRounds = ({
 					chainId={chainId}
 					setChoosedModalRound={setChoosedModalRound}
 					isQRDonation={isQRDonation}
+					onStellarDonation={onStellarDonation}
+					opensStellarFlow={opensStellarFlow}
+					getSwitchableNetworks={getSwitchableNetworks}
 				/>
 			)}
 		</>

--- a/src/components/views/donate/DonationCardQFRounds/QFRoundsModal.tsx
+++ b/src/components/views/donate/DonationCardQFRounds/QFRoundsModal.tsx
@@ -28,6 +28,11 @@ interface IQFRoundModalProps extends IModal {
 	chainId: number;
 	setChoosedModalRound: (round: IQFRound | undefined) => void;
 	isQRDonation?: boolean;
+	onStellarDonation?: () => void;
+	// Reachability predicates owned by DonationCardQFRounds — the same
+	// source of truth that filters the QFRounds list passed in.
+	opensStellarFlow: (round: IQFRound) => boolean;
+	getSwitchableNetworks: (round: IQFRound) => number[];
 }
 
 export const QFRoundsModal = ({
@@ -39,6 +44,9 @@ export const QFRoundsModal = ({
 	chainId,
 	setChoosedModalRound,
 	isQRDonation,
+	onStellarDonation,
+	opensStellarFlow,
+	getSwitchableNetworks,
 }: IQFRoundModalProps) => {
 	const { formatMessage, locale } = useIntl();
 	const [showSwitchModal, setShowSwitchModal] = useState(false);
@@ -57,25 +65,38 @@ export const QFRoundsModal = ({
 	);
 
 	const handleRoundSelect = (round: IQFRound) => {
+		// Stellar is not a wallet network: a Stellar-only round opens the
+		// Stellar (QR) donate flow directly — never the switch-network
+		// modal.
+		if (opensStellarFlow(round)) {
+			setCurrentSelected(round);
+			setChoosedModalRound(round);
+			onRoundSelect?.(round);
+			if (!isQRDonation) onStellarDonation?.();
+			closeModal();
+			return;
+		}
 		if (
 			round.eligibleNetworks.includes(chainId) ||
 			(isQRDonation &&
 				round.eligibleNetworks.includes(config.STELLAR_NETWORK_NUMBER))
 		) {
 			setCurrentSelected(round);
+			// Pin every explicit pick so the default-selection effect
+			// preserves it when its dependencies change (smart-select
+			// refetch, wallet network switch). The pin is released by the
+			// web3modal network-change handler and, for Stellar-only rounds,
+			// on backing out of the QR flow.
+			setChoosedModalRound(round);
 			onRoundSelect?.(round);
 			closeModal();
 		} else {
+			const switchableNetworks = getSwitchableNetworks(round);
+			// No network to switch to — never open an empty modal
+			// (unreachable for rounds in the grid, which are pre-filtered)
+			if (switchableNetworks.length === 0) return;
 			setClickedRound(round);
-			// Setup the networks for the newly selected round and only accepted by project
-			const projectAcceptedChains = project.addresses?.map(
-				address => address.networkId,
-			);
-			setAcceptedChains(
-				round.eligibleNetworks.filter(network =>
-					projectAcceptedChains?.includes(network),
-				),
-			);
+			setAcceptedChains(switchableNetworks);
 			setShowSwitchModal(true);
 		}
 	};
@@ -186,7 +207,9 @@ export const QFRoundsModal = ({
 						networkId: network,
 						chainType: config.EVM_NETWORKS_CONFIG[network]
 							? ChainType.EVM
-							: ChainType.SOLANA,
+							: network === config.STELLAR_NETWORK_NUMBER
+								? ChainType.STELLAR
+								: ChainType.SOLANA,
 					}))}
 					desc={
 						<FormattedMessage
@@ -200,6 +223,7 @@ export const QFRoundsModal = ({
 					clickedRound={clickedRound}
 					setChoosedModalRound={setChoosedModalRound}
 					onRoundSelect={onRoundSelect}
+					onStellarDonation={onStellarDonation}
 				/>
 			)}
 		</>

--- a/src/components/views/project/ProjectIndex.tsx
+++ b/src/components/views/project/ProjectIndex.tsx
@@ -26,7 +26,10 @@ import { IProjectBySlug } from '@/apollo/types/gqlTypes';
 import InlineToast, { EToastType } from '@/components/toasts/InlineToast';
 import SimilarProjects from '@/components/views/project/SimilarProjects';
 import { isSSRMode } from '@/lib/helpers';
-import { idToProjectEdit } from '@/lib/routeCreators';
+import {
+	idToProjectEdit,
+	slugToProjectDonateStellar,
+} from '@/lib/routeCreators';
 import { ProjectMeta } from '@/components/Metatag';
 import ProjectGIVPowerIndex from '@/components/views/project/projectGIVPower';
 import { useProjectContext } from '@/context/project.context';
@@ -42,7 +45,6 @@ import { AdminActions } from './projectActionCard/AdminActions';
 import ProjectOwnerBanner from './ProjectOwnerBanner';
 import ProjectSocials from './ProjectSocials';
 import ProjectDevouchBox from './ProjectDevouchBox';
-import Routes from '@/lib/constants/Routes';
 import { ChainType } from '@/types/config';
 import { useAppSelector } from '@/features/hooks';
 import { EndaomentProjectsInfo } from '@/components/views/project/EndaomentProjectsInfo';
@@ -204,9 +206,7 @@ const ProjectIndex: FC<IProjectBySlug> = () => {
 									</P>
 								</ToastText>
 							</Flex>
-							<Link
-								href={Routes.Donate + `/${slug}?chain=stellar`}
-							>
+							<Link href={slugToProjectDonateStellar(slug)}>
 								<LinkItem color={brandColors.giv[300]}>
 									{formatMessage({
 										id: 'page.project.donate_with_stellar',

--- a/src/components/views/project/projectActionCard/ProjectPublicActions.tsx
+++ b/src/components/views/project/projectActionCard/ProjectPublicActions.tsx
@@ -32,8 +32,11 @@ import {
 	slugToProjectDonateStellar,
 } from '@/lib/routeCreators';
 import { BadgeButton } from '@/components/project-card/ProjectCardBadgeButtons';
-import config from '@/configuration';
-import { getActiveRound } from '@/helpers/qf';
+import {
+	getActiveRound,
+	hasStellarAddress,
+	isStellarOnlyRound,
+} from '@/helpers/qf';
 
 export const ProjectPublicActions = () => {
 	const [showModal, setShowShareModal] = useState<boolean>(false);
@@ -57,10 +60,11 @@ export const ProjectPublicActions = () => {
 		project?.addresses?.length === 1 &&
 		project?.addresses[0]?.chainType === 'STELLAR';
 
-	const isStellarOnlyRound =
-		activeStartedRound?.eligibleNetworks?.length === 1 &&
-		activeStartedRound?.eligibleNetworks[0] ===
-			config.STELLAR_NETWORK_NUMBER;
+	// During an active, started Stellar-only round, Donate goes straight to
+	// the Stellar (QR) flow — provided the project can receive on Stellar.
+	const routeToStellarDonate =
+		isStellarOnlyRound(activeStartedRound) &&
+		hasStellarAddress(project?.addresses);
 
 	useEffect(() => {
 		const fetchProjectReaction = async () => {
@@ -138,7 +142,7 @@ export const ProjectPublicActions = () => {
 				id='Donate_Project'
 				href={
 					isActive
-						? isStellarOnlyRound
+						? routeToStellarDonate
 							? slugToProjectDonateStellar(slug || '')
 							: isCause
 								? slugToCauseDonate(slug || '')

--- a/src/helpers/qf.ts
+++ b/src/helpers/qf.ts
@@ -1,6 +1,8 @@
-import { IQFRound } from '@/apollo/types/types';
+import { IQFRound, IWalletAddress } from '@/apollo/types/types';
 import { getV6ActiveQfProjectRedirect } from '@/services/v6QF';
 import { getNowUnixMS } from './time';
+import config from '@/configuration';
+import { ChainType } from '@/types/config';
 // import { formatDonation } from '@/helpers/number';
 
 export const hasActiveRound = (qfRounds: IQFRound[] | undefined) => {
@@ -27,6 +29,18 @@ export const getActiveRound = (qfRounds: IQFRound[] | undefined) => {
 export const hasRoundStarted = (qfRound: IQFRound | null): boolean => {
 	return !!qfRound && new Date(qfRound.beginDate).getTime() < getNowUnixMS();
 };
+
+/**
+ * Stellar is not a wallet network: a round whose only eligible network is
+ * Stellar is donated to via the Stellar (QR) flow, never from a connected
+ * wallet.
+ */
+export const isStellarOnlyRound = (round?: IQFRound | null): boolean =>
+	round?.eligibleNetworks?.length === 1 &&
+	round.eligibleNetworks[0] === config.STELLAR_NETWORK_NUMBER;
+
+export const hasStellarAddress = (addresses?: IWalletAddress[]): boolean =>
+	!!addresses?.some(address => address.chainType === ChainType.STELLAR);
 
 /**
  * Single source of truth for the Stellar (QR) "sign in for GIVbacks" prompt.


### PR DESCRIPTION
##Issue
https://github.com/Giveth/giveth-dapps-v2/issues/5611

## Summary

This PR fixes QF round selection when Stellar is the only eligible network.

Stellar donations use the QR flow and do not require a wallet network switch. Selecting a Stellar-only round now opens the Stellar donation flow directly instead of showing the switch-network modal.

## Key changes

- Routes Stellar-only QF rounds directly to the Stellar QR donation flow.
- Shows only rounds and networks supported by both the project and the current donation flow.
- Prevents empty or unusable network-switch modals.
- Preserves manually selected rounds during smart-select updates.
- Recalculates round selection after wallet network changes or when leaving the Stellar flow.
- Routes project-card and project-page Donate buttons directly to Stellar when appropriate.
- Centralizes Stellar-round and Stellar-address checks in shared QF helpers.

## Review focus

Please verify:

- Selecting a Stellar-only round opens the QR flow without requesting a wallet network switch.
- Stellar rounds appear only for projects with a Stellar address.
- Mixed-network rounds still allow switching to EVM/Solana or entering the Stellar flow.
- Manual round selections remain selected after wallet and smart-select updates.
- Leaving the QR flow restores a valid round for the connected wallet network.
- Cause donation flows and projects without Stellar support are unaffected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enabled a direct Stellar QR donation flow for Stellar-only funding rounds, bypassing wallet/network switching.
  * Added optional Stellar-donation callbacks to the Stellar QR and round-selection modals to support this direct path.
* **Improvements**
  * Refined Stellar-only eligibility using Stellar address + round helper logic, updating both donation cards and project action/donation links.
  * Enhanced the round modal’s network handling to support Stellar chain typing and only prompt network switching when applicable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->