### PR TITLE
Remove tabs on Stellar donation page

### DIFF
--- a/src/components/views/donate/DonationCard.tsx
+++ b/src/components/views/donate/DonationCard.tsx
@@ -181,15 +181,17 @@ export const DonationCard: FC<IDonationCardProps> = ({
 
 	return (
 		<DonationCardHolder>
-			<DonationCardTabs
-				tab={tab}
-				setTab={setTab}
-				recurringEnabled={Boolean(
-					!disableRecurringDonations &&
-						(hasOpAddress || hasBaseAddress) &&
-						isOwnerOnEVM,
-				)}
-			/>
+			{!isQRDonation && (
+				<DonationCardTabs
+					tab={tab}
+					setTab={setTab}
+					recurringEnabled={Boolean(
+						!disableRecurringDonations &&
+							(hasOpAddress || hasBaseAddress) &&
+							isOwnerOnEVM,
+					)}
+				/>
+			)}
 			<DonationCardWrapper>
 				{tab === ETabs.ONE_TIME && (
 					<DonationCardQFRounds


### PR DESCRIPTION
## Related issue

https://github.com/Giveth/giveth-dapps-v2/issues/5610

## Description

Hides the **One-time / Recurring** donation tabs when a donor is using the Stellar QR donation flow.

Stellar donations are one-time QR-based donations, so these tabs are not applicable and could confuse donors. The tabs remain unchanged for regular EVM donation flows.

## Changes

- Conditionally hides `DonationCardTabs` for QR donations.
- Preserves the existing tab behavior for non-QR donations.

## How to test

1. Open a project’s Stellar QR donation page.
2. Verify the **One-time / Recurring** tabs are not displayed.
3. Verify the Stellar QR donation flow still works normally.
4. Open the regular donation page for an EVM-enabled project.
5. Verify the donation tabs are still displayed and functional.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed donation method tabs from the Stellar QR donation flow, preventing unavailable tab switching in QR mode.
  * Preserved recurring donation options in other donation flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->