### PR TITLE
Change round title color

### DIFF
--- a/src/components/views/projects/qfBanner/ActiveQFProjectsBanner.tsx
+++ b/src/components/views/projects/qfBanner/ActiveQFProjectsBanner.tsx
@@ -99,7 +99,10 @@ export const ActiveQFProjectsBanner = ({
 			<Container>
 				<ActiveStyledRow>
 					<ActiveStyledCol xs={12} md={6}>
-						<TitleWrapper weight={700}>
+						<TitleWrapper
+							weight={700}
+							color={neutralColors.gray[900]}
+						>
 							{currentRound ? currentRound.name : null}
 						</TitleWrapper>
 						{(state === ERoundStatus.NOT_STARTED ||

--- a/src/components/views/projects/qfBanner/common.ts
+++ b/src/components/views/projects/qfBanner/common.ts
@@ -63,7 +63,7 @@ export const ActiveStyledCol = styled(Col)`
 
 export const Title = styled(H1)`
 	margin-top: 32px;
-	color: ${neutralColors.gray[100]};
+	color: ${neutralColors.gray[900]};
 `;
 
 export const Desc = styled(Flex)`


### PR DESCRIPTION
## Issue

https://github.com/Giveth/giveth-dapps-v2/issues/5625

## Summary

Updates the QF round title color from white to `neutralColors.gray[900]` so it remains readable across approved banner designs.

- Applies to active and upcoming QF round banners
- Works consistently across desktop, tablet, and mobile
- Leaves the countdown timer styling unchanged

## How to test

1. Open a QF round page.
2. Verify the round title appears dark over the banner at all breakpoints.
3. Confirm the countdown timer color is unchanged.

Fixes #5625