### PR TITLE
Fix(format): show USD amounts with consistent 2-decimal formatting

### DIFF
--- a/src/components/RewardCard.tsx
+++ b/src/components/RewardCard.tsx
@@ -13,8 +13,10 @@ import {
 import React, { FC, MouseEventHandler, useEffect, useState } from 'react';
 import styled from 'styled-components';
 import { useIntl } from 'react-intl';
+import { formatEther } from 'viem';
 import { IconGIV } from './Icons/GIV';
 import { formatWeiHelper } from '@/helpers/number';
+import { formatUSD } from '@/lib/helpers';
 import { WhatIsStreamModal } from '@/components/modals/WhatIsStream';
 import useGIVTokenDistroHelper from '@/hooks/useGIVTokenDistroHelper';
 
@@ -110,7 +112,7 @@ export const RewardCard: FC<IRewardCardProps> = ({
 							<AmountUnit>{rewardTokenSymbol}</AmountUnit>
 						</AmountInfo>
 						<Converted>
-							~${formatWeiHelper(usdAmount.toString())}
+							~${formatUSD(formatEther(usdAmount))}
 						</Converted>
 						<RateInfo $alignItems='center' gap='8px'>
 							<IconGIVStream size={24} />

--- a/src/components/givfarm/RegenStreamCard.tsx
+++ b/src/components/givfarm/RegenStreamCard.tsx
@@ -20,7 +20,7 @@ import BigNumber from 'bignumber.js';
 import styled from 'styled-components';
 import { useIntl } from 'react-intl';
 import { useAccount } from 'wagmi';
-import { durationToString } from '@/lib/helpers';
+import { durationToString, formatUSD } from '@/lib/helpers';
 import { Bar, GsPTooltip } from '@/components/GIVeconomyPages/GIVstream.sc';
 import { IconWithTooltip } from '@/components/IconWithToolTip';
 import { RegenStreamConfig, StreamType } from '@/types/config';
@@ -103,11 +103,11 @@ export const RegenStreamCard: FC<RegenStreamProps> = ({ streamConfig }) => {
 		);
 		if (!price || price.isNaN()) return;
 
-		const usd = formatWeiHelper(
-			price.times(rewardLiquidPart.toString()).toFixed(0),
-			2,
-		);
-		setUSDAmount(usd);
+		const usd = price
+			.times(rewardLiquidPart.toString())
+			.div(10 ** 18)
+			.toFixed();
+		setUSDAmount(formatUSD(usd));
 	}, [
 		rewardLiquidPart,
 		chainId,

--- a/src/components/views/QFRounds/QFRoundCard.tsx
+++ b/src/components/views/QFRounds/QFRoundCard.tsx
@@ -13,7 +13,7 @@ import {
 } from '@giveth/ui-design-system';
 import { useIntl } from 'react-intl';
 import Link from 'next/link';
-import { thousandsSeparator, truncateText } from '@/lib/helpers';
+import { formatUSD, thousandsSeparator, truncateText } from '@/lib/helpers';
 
 type Layout = 'horizontal' | 'grid';
 
@@ -48,6 +48,12 @@ export default function QFRoundCard({
 }: QFRoundCardProps) {
 	const { formatMessage } = useIntl();
 
+	const matchingPool = allocatedFundUSDPreferred
+		? allocatedFundUSD != null
+			? formatUSD(allocatedFundUSD)
+			: undefined
+		: thousandsSeparator(allocatedFund);
+
 	return (
 		<Card $layout={layout}>
 			{layout === 'horizontal' ? (
@@ -77,11 +83,7 @@ export default function QFRoundCard({
 									<Chip $layout={layout}>
 										<span>
 											{allocatedFundUSDPreferred && '$'}
-											{thousandsSeparator(
-												allocatedFundUSDPreferred
-													? allocatedFundUSD
-													: allocatedFund,
-											) || ' --'}{' '}
+											{matchingPool || ' --'}{' '}
 											{!allocatedFundUSDPreferred &&
 												allocatedTokenSymbol}
 										</span>
@@ -146,11 +148,7 @@ export default function QFRoundCard({
 									<Chip $layout={layout}>
 										<span>
 											{allocatedFundUSDPreferred && '$'}
-											{thousandsSeparator(
-												allocatedFundUSDPreferred
-													? allocatedFundUSD
-													: allocatedFund,
-											) || ' --'}{' '}
+											{matchingPool || ' --'}{' '}
 											{!allocatedFundUSDPreferred &&
 												allocatedTokenSymbol}
 										</span>

--- a/src/components/views/archivedQFRounds/ArchivedQFRoundsTable.tsx
+++ b/src/components/views/archivedQFRounds/ArchivedQFRoundsTable.tsx
@@ -10,7 +10,7 @@ import {
 } from '@giveth/ui-design-system';
 import Link from 'next/link';
 import { IArchivedQFRound } from '@/apollo/types/types';
-import { formatDate, formatPrice } from '@/lib/helpers';
+import { formatDate, formatPrice, formatUSD } from '@/lib/helpers';
 import { Shadow } from '@/components/styled-components/Shadow';
 import Routes from '@/lib/constants/Routes';
 import { formatDonation } from '@/helpers/number';
@@ -39,7 +39,11 @@ export const ArchivedQFRoundsTable: FC<ArchivedQFRoundsTableProps> = ({
 						<P>
 							<Flex gap='1px'>
 								{!round.allocatedTokenSymbol && <span>$</span>}
-								<span>{formatPrice(round.allocatedFund)}</span>
+								<span>
+									{round.allocatedTokenSymbol
+										? formatPrice(round.allocatedFund)
+										: formatUSD(round.allocatedFund)}
+								</span>
 								{round.allocatedTokenSymbol && (
 									<span>{round.allocatedTokenSymbol}</span>
 								)}

--- a/src/components/views/donate/OneTime/SelectTokenModal/QRCodeDonation/QRDonationCard.tsx
+++ b/src/components/views/donate/OneTime/SelectTokenModal/QRCodeDonation/QRDonationCard.tsx
@@ -31,11 +31,8 @@ import { IProjectAcceptedToken } from '@/apollo/types/gqlTypes';
 import { fetchPriceWithCoingeckoId } from '@/services/token';
 import { ChainType } from '@/types/config';
 import config from '@/configuration';
-import {
-	truncateToDecimalPlaces,
-	formatBalance,
-	showToastError,
-} from '@/lib/helpers';
+import { truncateToDecimalPlaces, showToastError } from '@/lib/helpers';
+import { formatDonation } from '@/helpers/number';
 import { IDonationCardProps } from '../../../DonationCard';
 import QRDonationCardContent from './QRDonationCardContent';
 import {
@@ -385,9 +382,9 @@ export const QRDonationCard: FC<QRDonationCardProps> = ({
 	};
 
 	const calculateUsdAmount = (amount?: number) => {
-		if (!tokenPrice || !amount) return '0.00';
+		if (!tokenPrice || !amount) return '$0.00';
 
-		return formatBalance(amount * tokenPrice);
+		return formatDonation(amount * tokenPrice, '$');
 	};
 
 	useEffect(() => {
@@ -498,7 +495,7 @@ export const QRDonationCard: FC<QRDonationCardProps> = ({
 							<QRDonationInput>
 								<Input amount={amount} setAmount={setAmount} />
 								<UsdAmountCard>
-									$ {usdAmount.toFixed(2)}
+									{formatDonation(usdAmount, '$')}
 								</UsdAmountCard>
 							</QRDonationInput>
 						</StyledInputWrapper>

--- a/src/components/views/donate/OneTime/SelectTokenModal/QRCodeDonation/QRDonationCardContent.tsx
+++ b/src/components/views/donate/OneTime/SelectTokenModal/QRCodeDonation/QRDonationCardContent.tsx
@@ -128,10 +128,7 @@ const QRDonationCardContent: FC<IQRDonationCardContentProps> = ({
 				<AmountWrapper>
 					<Flex $alignItems='center' gap='2px'>
 						<B>{amount ?? '--'}</B>
-						<UsdAmountCard>
-							{' '}
-							{usdAmount ? `$ ${usdAmount}` : '--'}
-						</UsdAmountCard>
+						<UsdAmountCard> {usdAmount || '--'}</UsdAmountCard>
 						<IconArrowRight size={20} />
 					</Flex>
 					<Flex $alignItems='center' gap='2px'>

--- a/src/components/views/donate/OneTime/SelectTokenModal/QRCodeDonation/QRDonationDetails.tsx
+++ b/src/components/views/donate/OneTime/SelectTokenModal/QRCodeDonation/QRDonationDetails.tsx
@@ -20,7 +20,7 @@ import { TokenIcon } from '../../../TokenIcon/TokenIcon';
 import config from '@/configuration';
 import { ChainType } from '@/types/config';
 import { fetchPriceWithCoingeckoId } from '@/services/token';
-import { formatBalance } from '@/lib/helpers';
+import { formatDonation } from '@/helpers/number';
 import links from '@/lib/constants/links';
 import Routes from '@/lib/constants/Routes';
 import { useQRCodeDonation } from '@/hooks/useQRCodeDonation';
@@ -51,10 +51,10 @@ const QRDonationDetails = () => {
 
 	const convertToUSD = (amount: number) => {
 		if (!amount) return '--';
-		if (!tokenPrice) return '0.00';
+		if (!tokenPrice) return '$0.00';
 
 		const amountInUsd = tokenPrice * amount;
-		return formatBalance(amountInUsd);
+		return formatDonation(amountInUsd, '$');
 	};
 
 	const isFailedOperation = ['expired', 'failed'].includes(qrDonationStatus);
@@ -160,7 +160,7 @@ const QRDonationDetails = () => {
 					<FlexWrap $alignItems='center' gap='8px'>
 						<B>{draftDonationData?.amount ?? '--'}</B>
 						<UsdAmountCard>
-							$ {convertToUSD(draftDonationData?.amount!)}
+							{convertToUSD(draftDonationData?.amount!)}
 						</UsdAmountCard>
 						<Flex gap='8px' $alignItems='center'>
 							<TokenIcon

--- a/src/components/views/homepage/whyGiveth/DonationCard.tsx
+++ b/src/components/views/homepage/whyGiveth/DonationCard.tsx
@@ -7,7 +7,7 @@ import {
 	neutralColors,
 	Flex,
 } from '@giveth/ui-design-system';
-import { shortenAddress } from '@/lib/helpers';
+import { formatUSD, shortenAddress } from '@/lib/helpers';
 import { Shadow } from '@/components/styled-components/Shadow';
 import ExternalLink from '@/components/ExternalLink';
 import { slugToProjectView } from '@/lib/routeCreators';
@@ -35,7 +35,7 @@ const DonationCard: FC<IDonationCard> = props => {
 					<Section>
 						<B>{'@' + shortenAddress(address?.toLowerCase())}</B>
 						<div>donated</div>
-						<Amount>{'~$' + amount.toFixed(1)}</Amount>
+						<Amount>{'~$' + formatUSD(amount)}</Amount>
 					</Section>
 					<Section>
 						<Arrow>

--- a/src/components/views/projects/ActiveQFRoundStats.tsx
+++ b/src/components/views/projects/ActiveQFRoundStats.tsx
@@ -38,6 +38,12 @@ export const ActiveQFRoundStats = ({ qfRound }: { qfRound?: IQFRound }) => {
 		variables: { slug: currentRound?.slug },
 	});
 
+	const matchingPool = allocatedFundUSDPreferred
+		? allocatedFundUSD != null
+			? formatUSD(allocatedFundUSD)
+			: undefined
+		: thousandsSeparator(allocatedFund);
+
 	return (
 		<Wrapper>
 			<InfoSection $started={isRoundStarted}>
@@ -47,11 +53,7 @@ export const ActiveQFRoundStats = ({ qfRound }: { qfRound?: IQFRound }) => {
 					</ItemTitle>
 					<ItemValue weight={500}>
 						{allocatedFundUSDPreferred && '$'}
-						{thousandsSeparator(
-							allocatedFundUSDPreferred
-								? allocatedFundUSD
-								: allocatedFund,
-						) || ' --'}{' '}
+						{matchingPool || ' --'}{' '}
 						{!allocatedFundUSDPreferred && allocatedTokenSymbol}
 					</ItemValue>
 				</ItemContainer>

--- a/src/components/views/projects/ArchivedQFRoundStats.tsx
+++ b/src/components/views/projects/ArchivedQFRoundStats.tsx
@@ -32,6 +32,12 @@ export const ArchivedQFRoundStats = () => {
 		allocatedTokenSymbol,
 	} = qfRound || {};
 
+	const matchingPool = allocatedFundUSDPreferred
+		? allocatedFundUSD != null
+			? formatUSD(allocatedFundUSD)
+			: undefined
+		: thousandsSeparator(allocatedFund);
+
 	return (
 		<Wrapper>
 			<Smile src='/images/arc3.svg' width={70} height={100} alt='arc' />
@@ -45,11 +51,7 @@ export const ArchivedQFRoundStats = () => {
 					</ItemTitle>
 					<ItemValue>
 						{allocatedFundUSDPreferred && '$'}
-						{thousandsSeparator(
-							allocatedFundUSDPreferred
-								? allocatedFundUSD
-								: allocatedFund,
-						) || ' --'}{' '}
+						{matchingPool || ' --'}{' '}
 						{!allocatedFundUSDPreferred && allocatedTokenSymbol}
 					</ItemValue>
 				</ItemContainer>

--- a/src/components/views/transaction/DonationStatusSection.tsx
+++ b/src/components/views/transaction/DonationStatusSection.tsx
@@ -239,7 +239,7 @@ const DonationStatusSection: FC<TDonationStatusSectionProps> = ({
 					<Label>{formatMessage({ id: 'label.amount' })}</Label>
 					<FlexWrap $alignItems='center' gap='8px'>
 						<B>{draftDonationData?.amount}</B>
-						<UsdAmountCard>$ {usdAmount}</UsdAmountCard>
+						<UsdAmountCard>{usdAmount}</UsdAmountCard>
 						<TokenSymbol>
 							<TokenIcon
 								symbol={

--- a/src/components/views/transaction/Transaction.view.tsx
+++ b/src/components/views/transaction/Transaction.view.tsx
@@ -13,7 +13,7 @@ import {
 	FETCH_DRAFT_DONATION,
 } from '@/apollo/gql/gqlDonations';
 import { FETCH_PROJECT_BY_ID } from '@/apollo/gql/gqlProjects';
-import { formatBalance } from '@/lib/helpers';
+import { formatDonation } from '@/helpers/number';
 import config from '@/configuration';
 import { ChainType } from '@/types/config';
 import { fetchPriceWithCoingeckoId } from '@/services/token';
@@ -28,13 +28,13 @@ const TransactionView = () => {
 	const [draftDonationData, setDraftDonationData] =
 		useState<IDraftDonation | null>(null);
 	const [donationData, setDonationData] = useState<any>(null);
-	const [usdAmount, setUsdAmount] = useState<string>('0.00');
+	const [usdAmount, setUsdAmount] = useState<string>('$0.00');
 	const [isLoading, setIsLoading] = useState<boolean>(true);
 
 	const calculateUsdAmount = useCallback(
 		(tokenPrice?: number, amount?: number): string => {
-			if (!tokenPrice || !amount) return '0.00';
-			return formatBalance(amount * tokenPrice);
+			if (!tokenPrice || !amount) return '$0.00';
+			return formatDonation(amount * tokenPrice, '$');
 		},
 		[],
 	);
@@ -89,7 +89,7 @@ const TransactionView = () => {
 					fetchPolicy: 'no-cache',
 				});
 				setDonationData(donationById);
-				setUsdAmount(formatBalance(donationById.valueUsd));
+				setUsdAmount(formatDonation(donationById.valueUsd, '$'));
 			} else {
 				setUsdAmount(
 					calculateUsdAmount(

--- a/src/components/views/userProfile/projectsTab/ClaimRecurringDonationModal.tsx
+++ b/src/components/views/userProfile/projectsTab/ClaimRecurringDonationModal.tsx
@@ -144,7 +144,18 @@ const ClaimRecurringDonationModal = ({
 						<TotalAmountContainer>
 							<Flex $justifyContent='space-between'>
 								<B>Total amount claimable </B>
-								<B>~ {formatDonation(sumAllTokensUsd)} USD</B>
+								<B>
+									~{' '}
+									{formatDonation(
+										sumAllTokensUsd,
+										'',
+										undefined,
+										undefined,
+										undefined,
+										true,
+									)}{' '}
+									USD
+								</B>
 							</Flex>
 						</TotalAmountContainer>
 					</Flex>

--- a/src/components/views/userProfile/projectsTab/ClaimRecurringItem.tsx
+++ b/src/components/views/userProfile/projectsTab/ClaimRecurringItem.tsx
@@ -70,7 +70,14 @@ export const ClaimRecurringItem = ({
 						6,
 					)} 
                     ${tokenWithBalance.token.underlyingToken?.symbol} ~
-                    ${formatDonation(allTokensUsd[symbol]!)}
+                    ${formatDonation(
+						allTokensUsd[symbol]!,
+						'',
+						undefined,
+						undefined,
+						undefined,
+						true,
+					)}
                     USD
                 `}
 				</B>

--- a/src/components/views/userProfile/projectsTab/ClaimWithdrawalItem.tsx
+++ b/src/components/views/userProfile/projectsTab/ClaimWithdrawalItem.tsx
@@ -23,9 +23,14 @@ const ClaimWithdrawalItem = ({
 				{`${limitFraction(
 					utils.formatUnits(stream.balance, stream.token.decimals),
 					6,
-				)} ${
-					stream.token.underlyingToken?.symbol
-				} ~ ${formatDonation(balanceInUsd)} USD`}
+				)} ${stream.token.underlyingToken?.symbol} ~ ${formatDonation(
+					balanceInUsd,
+					'',
+					undefined,
+					undefined,
+					undefined,
+					true,
+				)} USD`}
 			</B>
 		</Container>
 	);

--- a/src/components/views/userProfile/projectsTab/ProjectItem.tsx
+++ b/src/components/views/userProfile/projectsTab/ProjectItem.tsx
@@ -284,6 +284,9 @@ const ProjectItem: FC<IProjectItem> = props => {
 										project.ownerTotalEarnedUsdValue || 0,
 										'',
 										locale,
+										undefined,
+										undefined,
+										true,
 									)}
 									USD
 								</span>

--- a/src/helpers/number.ts
+++ b/src/helpers/number.ts
@@ -1,7 +1,7 @@
 import BigNumber from 'bignumber.js';
 import { formatEther, formatUnits } from 'viem';
 import config from '@/configuration';
-import { truncateToDecimalPlaces } from '@/lib/helpers';
+import { truncateToDecimalPlaces, usdFractionDigits } from '@/lib/helpers';
 
 export const Zero = new BigNumber(0);
 
@@ -56,6 +56,9 @@ export const formatDonation = (
 	local: Intl.LocalesArgument = 'en-US',
 	rounded: boolean = false,
 	maximumFractionDigits: number = 2,
+	// A '$' symbol means the amount is USD. Amounts labelled with a 'USD' suffix
+	// instead of a '$' prefix have to opt in so they get the same 2 decimals.
+	isUSD: boolean = symbol === '$',
 ): string => {
 	if (amount === '<0.000001') {
 		return '< 0.01';
@@ -69,9 +72,17 @@ export const formatDonation = (
 			: `${symbol}${threshold.toString().replace('1', '0')}`;
 	}
 	if (num < threshold) return `< ${symbol}${threshold}`;
-	return !rounded
-		? symbol + num.toLocaleString(local, { maximumFractionDigits })
-		: symbol + Math.round(num).toLocaleString(local);
+	if (rounded) return symbol + Math.round(num).toLocaleString(local);
+	// USD amounts always show 2 decimals when they aren't a whole amount
+	return (
+		symbol +
+		num.toLocaleString(
+			local,
+			isUSD
+				? usdFractionDigits(num, maximumFractionDigits)
+				: { maximumFractionDigits },
+		)
+	);
 };
 
 export function limitFraction(

--- a/src/lib/helpers.ts
+++ b/src/lib/helpers.ts
@@ -38,17 +38,29 @@ const locales = process.env.locales;
 
 export const fullPath = (path: string) => `${config.FRONTEND_LINK}${path}`;
 
-export const formatBalance = (balance?: string | number) => {
-	return parseFloat(String(balance || 0)).toLocaleString('en-US', {
-		maximumFractionDigits: 6,
-		minimumFractionDigits: 2,
-	});
+/**
+ * USD amounts are never shown with a partial decimal: when there is any
+ * fractional part it's displayed with exactly 2 decimals (2.6 -> 2.60), while
+ * whole amounts stay whole (4000 -> 4,000).
+ */
+export const usdFractionDigits = (
+	amount: number,
+	maximumFractionDigits = 2,
+): Intl.NumberFormatOptions => {
+	const hasDecimals = !Number.isInteger(
+		Number(amount.toFixed(maximumFractionDigits)),
+	);
+	return {
+		maximumFractionDigits,
+		minimumFractionDigits: hasDecimals
+			? Math.min(2, maximumFractionDigits)
+			: 0,
+	};
 };
 
 export const formatUSD = (balance?: string | number, decimals = 2) => {
-	return parseFloat(String(balance || 0)).toLocaleString('en-US', {
-		maximumFractionDigits: decimals,
-	});
+	const amount = parseFloat(String(balance || 0));
+	return amount.toLocaleString('en-US', usdFractionDigits(amount, decimals));
 };
 
 export const formatPrice = (balance?: string | number) => {


### PR DESCRIPTION
## Issue

https://github.com/Giveth/giveth-dapps-v2/issues/5626

## Summary

Standardizes USD amount formatting across the app so fractional values display consistently with two decimal places, while whole-dollar amounts remain unchanged.

Examples:

- `2.6` → `2.60`
- `2.614` → `2.61`
- `4,000` → `4,000`

## Changes

- Added shared USD fraction-digit formatting.
- Updated `formatUSD` and `formatDonation` to consistently format USD values.
- Applied the formatting across:
  - Project and donation views
  - QF round cards and statistics
  - Stellar QR donation flows
  - Transaction status views
  - GIVstream and reward cards
  - Recurring donation claims and withdrawals
- Preserved existing formatting for non-USD token amounts.

## Testing

- Verify fractional USD amounts display with two decimal places.
- Verify whole-dollar amounts do not receive unnecessary `.00`.
- Verify `$`-prefixed and `USD`-suffixed values follow the same formatting.
- Verify non-USD token amounts retain their existing precision.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Standardized USD formatting across rewards, donations, matching pools, recurring claims, withdrawals, and earnings.
  * Improved currency precision, decimal handling, thousand separators, and fallback values such as `$0.00`.
  * Updated QR donation displays to show consistent dollar formatting.
  * Matching pool amounts now clearly distinguish USD values from token-denominated amounts.
  * Corrected reward and donation conversions for more accurate displayed USD amounts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->